### PR TITLE
Update documentation and entry templates with current practices

### DIFF
--- a/docs/02-adding-content/adding-a-project.md
+++ b/docs/02-adding-content/adding-a-project.md
@@ -110,6 +110,22 @@ Add as many sections as you need to tell the project story.
 
 See [Frontmatter Reference](frontmatter-reference.md) for details on all available fields.
 
+### Image File Naming Conventions
+
+When you add images to your project, use these naming conventions:
+
+| Prefix | Example | Purpose |
+|--------|---------|---------|
+| `header.jpg` | `header.jpg` | Main thumbnail shown in index + top of project page |
+| `00_`, `01_`, etc. | `00_Exterior view.jpg` | Gallery photos (numbered for sort order) |
+| `drawing-` | `drawing-plan_1.jpg` | Floor plans and architectural drawings |
+| `toolkit-` | `toolkit-framing-plan.dwg` | Reference files (CAD, PDF, DWG, etc.) |
+
+**Numbering tip:** Use zero-padded numbers to control order:
+- `00_name.jpg` ← Appears first
+- `01_name.jpg` ← Appears second
+- `02_name.jpg` ← Appears third
+
 ### Step 4: Commit the File
 
 1. Scroll down to "Commit changes"

--- a/docs/02-adding-content/frontmatter-reference.md
+++ b/docs/02-adding-content/frontmatter-reference.md
@@ -189,6 +189,51 @@ collaborators:
 - List primary collaborators first
 - Be specific with roles
 
+### location
+
+**What it does:** Geographic location of the project.
+
+**Format:** Text in quotes
+
+**Example:**
+```yaml
+location: "Austin, TX, USA"
+```
+
+**Tips:**
+- Be specific: city, state, country
+- Optional but helpful for context
+
+### status
+
+**What it does:** Current status of the project (Built, In Progress, Proposed, etc.).
+
+**Format:** Text in quotes
+
+**Example:**
+```yaml
+status: "Built"
+```
+
+**Tips:**
+- Use consistent values: "Built", "In Progress", "Proposed", "Concept"
+- Helps visitors understand project phase
+
+### featured
+
+**What it does:** Highlight projects or awards for special display.
+
+**Format:** `true` or `false` (no quotes)
+
+**Example:**
+```yaml
+featured: true
+```
+
+**Tips:**
+- `featured: true` may be used by the site for special display areas
+- `featured: false` (default) means normal display
+
 ### description (Projects)
 
 **What it does:** Short project summary.

--- a/docs/02-adding-content/image-guide.md
+++ b/docs/02-adding-content/image-guide.md
@@ -70,16 +70,23 @@ If neither exists, the system will use the first image it finds alphabetically.
 
 ### For Projects (Gallery Images)
 
-Name gallery images in order with descriptive names:
+Use these file naming prefixes:
 
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `00_`, `01_`, etc. | Gallery photos (numbered for sort order) | `00_Exterior view.jpg` |
+| `drawing-` | Floor plans and architectural drawings | `drawing-plan_1.jpg` |
+| `toolkit-` | Reference files (CAD, PDF, DWG) | `toolkit-framing-plan.dwg` |
+
+**Gallery images in alphabetical order:**
 ```
-01-exterior-view.jpg
-02-interior-space.jpg
-03-detail-shot.jpg
-04-community-area.jpg
+00_exterior-view.jpg
+01_interior-space.jpg
+02_detail-shot.jpg
+03_community-area.jpg
 ```
 
-The numbers keep them in order; the descriptions help you identify them.
+The numbers keep them in order; the descriptions help you identify them. Note the underscore (`_`) in numbered filenames, which ensures proper alphabetical sort order.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,118 +1,36 @@
 # LowDO Website Documentation
 
-Welcome to the LowDO website documentation! This guide will help you add content, customize the site, and understand how everything works.
-
-## New to Editing This Site?
-
-✨ **Good news:** You can edit this entire website using just your web browser—no software to install!
-
-👉 **[Start Here Guide](00-start-here.md)** - Quick orientation
-
-### Two Ways to Edit
-
-1. **GitHub Web Editor** (Recommended for beginners)
-   - Edit files directly on GitHub.com
-   - No installation required
-   - Works on any device with a browser
-   - Use AI assistants (Claude, ChatGPT) for help
-
-2. **Local Development** (Optional, for advanced users)
-   - Install VS Code on your computer
-   - Faster feedback and testing
-   - Better for complex changes
-
-Most content editors can do everything they need with just the web editor!
+**[Getting Started →](getting-started.md)** — New to editing? Start here.
 
 ---
 
-## Documentation by Topic
+## Adding Content
 
-### 🆕 Adding New Content
+- [How to Add a Project](02-adding-content/adding-a-project.md) — Complete guide with file naming conventions
+- [How to Add News, Awards, & More](02-adding-content/adding-news-awards.md) — Festivals, lectures, exhibitions, and staff updates
+- [Image Guide](02-adding-content/image-guide.md) — Best practices for image naming and uploading
+- [Frontmatter Reference](02-adding-content/frontmatter-reference.md) — Complete field guide
 
-Learn how to add projects, news, awards, and other content to the site:
+## Editing & Customizing
 
-- **[How to Add a Project](02-adding-content/adding-a-project.md)** - Step-by-step guide for design projects
-- **[How to Add News, Awards, & More](02-adding-content/adding-news-awards.md)** - Adding non-project entries
-- **[Image Guide](02-adding-content/image-guide.md)** - Best practices for naming and uploading images
-- **[Frontmatter Reference](02-adding-content/frontmatter-reference.md)** - Complete field-by-field guide
+- [Editing Existing Entries](03-editing-content/editing-existing-entries.md) — Update, hide, or reorganize content
+- [Customizing the Site](04-customizing-the-site/changing-colors.md) — Change colors, title, contact info
+- [GitHub Web Editor](05-tools-and-workflow/github-web-editor.md) — Edit files in your browser (no installation)
 
-### ✏️ Editing Existing Content
+## Tools & Workflow
 
-Modify, hide, or reorganize published content:
+- [Git for Beginners](05-tools-and-workflow/git-for-beginners.md) — Version control basics
+- [Making Commits](05-tools-and-workflow/making-commits.md) — How to save and publish changes
+- [Local Development](05-tools-and-workflow/code-editor-setup.md) — VS Code setup and preview
 
-- **[Editing Existing Entries](03-editing-content/editing-existing-entries.md)** - How to modify published content
-- **[Hiding/Unpublishing Content](03-editing-content/hiding-unpublishing.md)** - Using `draft: true`
-- **[Organizing Entries](03-editing-content/organizing-entries.md)** - Categories, sort order, and dates
+## Help & Reference
 
-### 🎨 Customizing the Site
-
-Change colors, text, and site settings:
-
-- **[Changing Colors](04-customizing-the-site/changing-colors.md)** - Edit theme colors without coding
-- **[Updating Site Info](04-customizing-the-site/updating-site-info.md)** - Site title, contact, social links
-- **[Settings Reference](04-customizing-the-site/settings-reference.md)** - Complete guide to settings.yaml
-- **[Basic CSS Edits](04-customizing-the-site/editing-css-basics.md)** - Simple CSS tweaks for brave beginners
-
-### 🛠️ Tools and Workflow
-
-Set up your workspace and publish changes:
-
-- **[Code Editor Setup](05-tools-and-workflow/code-editor-setup.md)** - Installing and using VS Code
-- **[Claude Code Basics](05-tools-and-workflow/claude-code-basics.md)** - Using the AI coding assistant
-- **[Git for Beginners](05-tools-and-workflow/git-for-beginners.md)** - Understanding version control
-- **[Making Commits](05-tools-and-workflow/making-commits.md)** - How to save and publish changes
-- **[Viewing Changes Live](05-tools-and-workflow/viewing-changes-live.md)** - Netlify previews and deployment
-
-### ❓ Troubleshooting
-
-Fix common problems:
-
-- **[Common Issues](06-troubleshooting/common-issues.md)** - "My entry doesn't show up", etc.
-- **[Image Problems](06-troubleshooting/image-problems.md)** - Image not appearing or wrong size
-- **[FAQ](06-troubleshooting/faq.md)** - Frequently asked questions
-
-### 📖 Understanding the Site
-
-Learn how the site works:
-
-- **[How the Site Works](01-understanding-the-site/how-the-site-works.md)** - High-level overview in plain language
-- **[Folder Structure](01-understanding-the-site/folder-structure.md)** - Where everything lives
-- **[Comprehensive Index Guide](01-understanding-the-site/comprehensive-index-guide.md)** - How the index page works
-
-### 📚 Reference Materials
-
-Quick references and guidelines:
-
-- **[File Naming Conventions](07-reference/file-naming-conventions.md)** - Naming rules and best practices
-- **[Category Guidelines](07-reference/category-guidelines.md)** - When to use which categories
-- **[Entry Types Comparison](07-reference/entry-types-comparison.md)** - Projects vs. News vs. Awards
-- **[Glossary](07-reference/glossary.md)** - Jargon decoder (git, frontmatter, etc.)
+- [Troubleshooting](06-troubleshooting/common-issues.md) — Fix common issues
+- [FAQ](06-troubleshooting/faq.md) — Frequently asked questions
+- [Glossary](07-reference/glossary.md) — Terminology
+- [Entry Types](07-reference/entry-types-comparison.md) — Projects vs. news vs. awards
+- [Categories](07-reference/category-guidelines.md) — How to use categories
 
 ---
 
-## For Advanced Users
-
-If you're comfortable with code and want to dive deeper into the technical implementation:
-
-- **[CLAUDE.md](../CLAUDE.md)** - Technical documentation for developers
-- **[Local Development Workflow.md](../Local%20Development%20Workflow.md)** - Git and deployment workflow
-
----
-
-## Getting Help
-
-If you're stuck or have questions:
-
-1. Check the **[FAQ](06-troubleshooting/faq.md)** for quick answers
-2. Review the **[Troubleshooting](06-troubleshooting/common-issues.md)** guides
-3. Ask a team member or email lowdo@lowdo.net
-
----
-
-## Quick Links
-
-**Most Common Tasks:**
-- [Add a project](02-adding-content/adding-a-project.md)
-- [Add news/award](02-adding-content/adding-news-awards.md)
-- [Change site colors](04-customizing-the-site/changing-colors.md)
-- [Make a commit](05-tools-and-workflow/making-commits.md)
+Email lowdo@lowdo.net with questions.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,104 @@
+# Getting Started
+
+Welcome to the LowDO website! This guide will help you understand how the site works and get oriented to editing content.
+
+---
+
+## What Can You Do Without Knowing How to Code?
+
+You can do everything:
+
+✅ **Add new content** — Design projects, news, awards, press features, lectures, exhibitions, staff updates
+✅ **Edit existing content** — Update descriptions, dates, categories, metadata, hide content
+✅ **Customize the site** — Change colors, themes, site title, contact information
+✅ **Publish changes** — Save and deploy to live site (no manual builds)
+
+❌ **What you CAN'T do easily** — Change layout/structure, add new features, modify code (ask an AI assistant for these)
+
+---
+
+## What You'll Need
+
+### Required
+- Web browser (Chrome, Firefox, Safari, etc.)
+- GitHub account with access to lowdo-dot-net repository
+- This documentation
+
+### Optional (But Helpful)
+- VS Code text editor for local editing
+- Git command-line tools
+
+**Most people can edit everything using just their web browser!**
+
+---
+
+## How the Site Works
+
+### The Big Picture
+
+LowDO is a **static site**, meaning:
+
+- **Content lives in text files** (not a database like WordPress)
+- **Pages are pre-built** — When you add content, the system automatically generates HTML pages
+- **Everything is automatic** — You add folders/files, the system handles discovery, image optimization, and index updates
+- **Fast & secure** — Static sites load instantly and are harder to hack
+
+### The Workflow
+
+```
+You create/edit files on GitHub
+        ↓
+Netlify detects changes
+        ↓
+Eleventy build system runs (3-5 min)
+        ↓
+Site rebuilds with your content
+        ↓
+Changes go live at lowdo.netlify.app
+```
+
+### Content Types
+
+**Projects** — Get their own detail pages with galleries
+- Folder: `entries/projects/{project-name}/`
+- URL: `/project/{project-name}/`
+
+**Updates** — Appear in the comprehensive index at `/all/`, no individual pages
+- News, awards, features, lectures, exhibitions, staff
+- Folders: `entries/{type}/{entry-name}/`
+
+### The Automatic System
+
+✅ **Automatic:**
+- File discovery — add a file and it appears on the site
+- Image discovery — drop images in a folder and they're added to the gallery
+- Index updates — comprehensive index automatically shows new entries
+- Filter generation — categories automatically become filter options
+- Image optimization — images are automatically resized and compressed
+
+### Where Changes Happen
+
+**Files you edit:**
+- `entries/` — All content (projects, news, awards, etc.)
+- `_data/settings.yaml` — Site colors, title, email
+
+**Don't touch:**
+- `_includes/` — HTML templates and code
+- `_site/` — Auto-generated output
+
+---
+
+## Next Steps
+
+1. **[Adding Content](adding-content/adding-a-project.md)** — How to add your first project
+2. **[GitHub Web Editor](tools/github-web-editor.md)** — How to edit using your web browser
+3. **[Frontmatter Reference](adding-content/frontmatter.md)** — Complete guide to entry fields
+4. **[Customizing the Site](customizing.md)** — How to change colors and info
+
+---
+
+## Questions?
+
+- Check [Troubleshooting](troubleshooting.md)
+- Ask an AI assistant (Claude, ChatGPT, etc.)
+- Email lowdo@lowdo.net

--- a/entries/awards/_template-award/_template-award.md
+++ b/entries/awards/_template-award/_template-award.md
@@ -23,17 +23,13 @@ You can include:
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-award` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `emerging-voices-2024`)
-3. **Rename the .md file:** Must match the folder name (e.g., `emerging-voices-2024.md`)
-4. **Add thumbnail (optional):** Add `thumb.jpg` or `header.jpg` for an image
-5. **Edit frontmatter:** Update all fields between the `---` lines
-   - The `link:` field should point to the award announcement or organization
-   - Adjust categories (AWARD, PRESS, RECOGNITION, etc.)
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with award details
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file (e.g., `emerging-voices-2024`)
+3. Edit frontmatter fields above
+4. Add optional image: `header.jpg` or `thumb.jpg`
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding News/Awards guide](../../docs/02-adding-content/adding-news-awards.md)
+See [Adding News/Awards](../../docs/02-adding-content/adding-updates.md) for help.

--- a/entries/exhibitions/_template-exhibition/_template-exhibition.md
+++ b/entries/exhibitions/_template-exhibition/_template-exhibition.md
@@ -24,17 +24,13 @@ You can include:
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-exhibition` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `gallery-show-2024`)
-3. **Rename the .md file:** Must match the folder name (e.g., `gallery-show-2024.md`)
-4. **Add thumbnail (optional):** Add `thumb.jpg` or `header.jpg` (exhibition photo, poster, etc.)
-5. **Edit frontmatter:** Update all fields between the `---` lines
-   - The `link:` field can point to gallery page, event listing, or announcement
-   - Adjust categories (EXHIBITION, ART, INSTALLATION, SHOW, etc.)
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with exhibition details
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file (e.g., `gallery-show-2024`)
+3. Edit frontmatter fields above
+4. Add optional image: `header.jpg` or `thumb.jpg`
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding News/Awards guide](../../docs/02-adding-content/adding-news-awards.md)
+See [Adding News/Awards](../../docs/02-adding-content/adding-updates.md) for help.

--- a/entries/features/_template-feature/_template-feature.md
+++ b/entries/features/_template-feature/_template-feature.md
@@ -23,17 +23,13 @@ You can include:
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-feature` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `architect-magazine-2024`)
-3. **Rename the .md file:** Must match the folder name (e.g., `architect-magazine-2024.md`)
-4. **Add thumbnail (optional):** Add `thumb.jpg` or `header.jpg` (magazine cover, screenshot, etc.)
-5. **Edit frontmatter:** Update all fields between the `---` lines
-   - The `link:` field should point to the online article or publication
-   - Adjust categories (PRESS, PUBLICATION, MEDIA, FEATURE, etc.)
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with feature details
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file (e.g., `architect-magazine-2024`)
+3. Edit frontmatter fields above
+4. Add optional image: `header.jpg` or `thumb.jpg`
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding News/Awards guide](../../docs/02-adding-content/adding-news-awards.md)
+See [Adding News/Awards](../../docs/02-adding-content/adding-updates.md) for help.

--- a/entries/lectures/_template-lecture/_template-lecture.md
+++ b/entries/lectures/_template-lecture/_template-lecture.md
@@ -23,17 +23,13 @@ You can include:
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-lecture` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `utsoa-talk-2024`)
-3. **Rename the .md file:** Must match the folder name (e.g., `utsoa-talk-2024.md`)
-4. **Add thumbnail (optional):** Add `thumb.jpg` or `header.jpg` (event poster, venue photo, etc.)
-5. **Edit frontmatter:** Update all fields between the `---` lines
-   - The `link:` field can point to event page, video, or organization
-   - Adjust categories (LECTURE, EDUCATION, PRESENTATION, WORKSHOP, etc.)
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with lecture details
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file (e.g., `utsoa-talk-2024`)
+3. Edit frontmatter fields above
+4. Add optional image: `header.jpg` or `thumb.jpg`
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding News/Awards guide](../../docs/02-adding-content/adding-news-awards.md)
+See [Adding News/Awards](../../docs/02-adding-content/adding-updates.md) for help.

--- a/entries/news/_template-news/_template-news.md
+++ b/entries/news/_template-news/_template-news.md
@@ -24,17 +24,13 @@ Keep it concise - news entries don't get their own pages, they only appear in th
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-news` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `studio-expansion`)
-3. **Rename the .md file:** Must match the folder name (e.g., `studio-expansion.md`)
-4. **Add thumbnail (optional):** Add `thumb.jpg` or `header.jpg` for an image
-5. **Edit frontmatter:** Update all fields between the `---` lines
-   - Remove the `link:` field if you don't have an external URL
-   - Adjust categories as needed (NEWS, STUDIO, EVENT, etc.)
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with your announcement
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file (e.g., `studio-expansion`)
+3. Edit frontmatter fields above
+4. Add optional image: `header.jpg` or `thumb.jpg`
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding News/Awards guide](../../docs/02-adding-content/adding-news-awards.md)
+See [Adding News/Awards](../../docs/02-adding-content/adding-updates.md) for help.

--- a/entries/projects/_template-project/README.md
+++ b/entries/projects/_template-project/README.md
@@ -1,18 +1,19 @@
 # Template Project
 
-This is a template folder you can duplicate to create new projects.
+Duplicate this folder to create a new project. See the `.md` file for detailed instructions.
 
-## How to Use
+## File Naming Conventions
 
-1. **Duplicate this entire folder**
-2. **Rename the folder** to your project name (lowercase, use hyphens)
-3. **Rename the `.md` file** to match the folder name
-4. **Add your images:**
-   - `header.jpg` - Main thumbnail (required)
-   - `01-description.jpg`, `02-description.jpg`, etc. - Gallery images (optional)
-5. **Edit the frontmatter** in the `.md` file
-6. **Change `draft: true` to `draft: false`** when ready to publish
+| Prefix | Example | Purpose |
+|--------|---------|---------|
+| `header.jpg` | `header.jpg` | Main thumbnail for index |
+| `00_`, `01_`, etc. | `00_Exterior view.jpg` | Gallery photos (numbered) |
+| `drawing-` | `drawing-plan_1.jpg` | Floor plans, technical drawings |
+| `toolkit-` | `toolkit-framing-plan.dwg` | Reference files (CAD, PDF, DWG) |
 
-## Need Help?
+**Numbering:** Use underscores and zero-padded numbers to control sort order:
+- `00_name.jpg` ← First
+- `01_name.jpg` ← Second
+- `02_name.jpg` ← Third
 
-See the [Adding a Project guide](../../docs/02-adding-content/adding-a-project.md)
+See [Image Guide](../../docs/02-adding-content/images.md) for more help.

--- a/entries/projects/_template-project/_template-project.md
+++ b/entries/projects/_template-project/_template-project.md
@@ -1,13 +1,15 @@
 ---
 draft: true
 title: "Your Project Name"
-subtitle: "Brief tagline or description"
 description: "A short summary of the project (1-2 sentences)"
 date: 2024-01-15
 year: 2024
 categories:
   - HOUSING
   - SUSTAINABLE
+location: ""  # e.g., "Austin, TX"
+status: ""    # e.g., "Built", "In Progress"
+featured: false
 collaborators:
   - name: "Partner Name"
     role: "Structural Engineer"
@@ -43,17 +45,22 @@ Keep paragraphs short for readability on the web.
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-project` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `my-project-name`)
-3. **Rename the .md file:** Must match the folder name (e.g., `my-project-name.md`)
-4. **Add images:**
-   - Main thumbnail: `header.jpg` or `thumb.jpg`
-   - Gallery images: `01-description.jpg`, `02-description.jpg`, etc.
-5. **Edit frontmatter:** Update all fields between the `---` lines
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with your project description
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file to match your project (e.g., `my-project-name`)
+3. Edit frontmatter (metadata between `---` lines)
+4. Add images (see image naming conventions below)
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding a Project guide](../../docs/02-adding-content/adding-a-project.md)
+**Image File Naming:**
+
+| Name | Purpose | Example |
+|------|---------|---------|
+| `header.jpg` | Main thumbnail | `header.jpg` |
+| `00_`, `01_`, etc. | Gallery photos (numbered) | `00_Exterior view.jpg` |
+| `drawing-` | Floor plans, drawings | `drawing-plan_1.jpg` |
+| `toolkit-` | Reference files (CAD, PDF) | `toolkit-framing-plan.dwg` |
+
+See [Adding a Project](../../docs/02-adding-content/adding-a-project.md) guide for detailed help.

--- a/entries/staff/_template-staff/_template-staff.md
+++ b/entries/staff/_template-staff/_template-staff.md
@@ -5,7 +5,8 @@ subtitle: "New Role or Update Type"
 description: "Brief description of the update"
 date: 2024-01-15
 categories:
-  - TEAM
+  - STAFF
+  - NEWS
 link: ""
 position: 1
 ---
@@ -23,17 +24,13 @@ You can include:
 
 ---
 
-## Instructions for Using This Template
+## How to Use This Template
 
-1. **Duplicate this folder:** Copy the entire `_template-staff` folder
-2. **Rename the folder:** Use lowercase and hyphens (e.g., `jane-doe-joins`)
-3. **Rename the .md file:** Must match the folder name (e.g., `jane-doe-joins.md`)
-4. **Add thumbnail (optional):** Add `thumb.jpg` or `header.jpg` (headshot, team photo, etc.)
-5. **Edit frontmatter:** Update all fields between the `---` lines
-   - Remove the `link:` field or leave it empty if not needed
-   - Adjust categories (STAFF, TEAM, HIRE, PROMOTION, DEPARTURE, etc.)
-6. **Set draft to false:** Change `draft: true` to `draft: false` when ready to publish
-7. **Write content:** Replace this template text with staff update details
-8. **Delete this section:** Remove these instructions before publishing
+1. Duplicate this entire folder
+2. Rename folder and `.md` file (e.g., `jane-doe-joins`)
+3. Edit frontmatter fields above
+4. Add optional image: `header.jpg` or `thumb.jpg`
+5. Change `draft: true` to `draft: false` to publish
+6. Delete these instructions before publishing
 
-Need help? See the [Adding News/Awards guide](../../docs/02-adding-content/adding-news-awards.md)
+See [Adding News/Awards](../../docs/02-adding-content/adding-updates.md) for help.


### PR DESCRIPTION
- Add getting-started.md as new entry point for documentation
- Streamline docs/README.md: clean index focusing on common tasks
- Update project template with missing fields: featured, location, status
- Fix project template image naming: use underscores in numbered images (00_name.jpg not 01-name.jpg)
- Add image file naming conventions table to adding-a-project.md
- Add prefix documentation: drawing- and toolkit- for non-photo files
- Update all 7 entry templates with shorter, clearer instructions
- Fix staff template example categories: STAFF + NEWS (matches real usage)
- Add undocumented fields to frontmatter reference: featured, location, status