### PR TITLE
Fix null reference error in category join filters

### DIFF
--- a/_includes/components/indexRow.njk
+++ b/_includes/components/indexRow.njk
@@ -4,7 +4,7 @@
   <a href="{{ entry.data.link }}" class="index-row-link" target="_blank" rel="noopener">
 {% endif %}
 
-<div class="index-row grid grid--index" data-entry-type="{{ entry.data.entryType }}" data-categories="{% if entry.data.categories %}{{ entry.data.categories | join(',') | lower }}{% endif %}">
+<div class="index-row grid grid--index" data-entry-type="{{ entry.data.entryType }}" data-categories="{% if entry.data.categories and entry.data.categories.length %}{{ entry.data.categories | join(',') | lower }}{% endif %}">
 
   {# Column 1: Thumbnail Image #}
   <div class="index-col index-col--image">
@@ -26,7 +26,7 @@
   {# Column 3: Details/Description #}
   <div class="index-col index-col--details">
     {% if entry.data.entryType or entry.data.categories %}
-      <span class="index-row__categories">{% if entry.data.entryType %}{{ entry.data.entryType | upper }}{% endif %}{% if entry.data.entryType and entry.data.categories %}, {% endif %}{% if entry.data.categories %}{{ entry.data.categories | join(', ') | upper }}{% endif %}</span>
+      <span class="index-row__categories">{% if entry.data.entryType %}{{ entry.data.entryType | upper }}{% endif %}{% if entry.data.entryType and entry.data.categories and entry.data.categories.length %}, {% endif %}{% if entry.data.categories and entry.data.categories.length %}{{ entry.data.categories | join(', ') | upper }}{% endif %}</span>
     {% endif %}
     {% if entry.data.collaborators and entry.data.collaborators.length %}
       <span class="index-row__collaborators">

--- a/_includes/layouts/project.njk
+++ b/_includes/layouts/project.njk
@@ -1110,7 +1110,7 @@ section: project
             {% if description %}{{ description | renderUsingMarkdown | safe }}{% endif %}
           </div>
           <div class="project-meta-tags">
-            {% if categories %}{{ categories | join(', ') | upper }}{% endif %}
+            {% if categories and categories.length %}{{ categories | join(', ') | upper }}{% endif %}
           </div>
         </div>
 
@@ -1175,7 +1175,7 @@ section: project
                   {{ item.data.title }}
                 {% endif %}
               </div>
-              <div class="project-collab-cell">{{ item.data.categories | join(', ') | upper }} ({{ item.data.date | formatDate("YYYY") }})</div>
+              <div class="project-collab-cell">{% if item.data.categories and item.data.categories.length %}{{ item.data.categories | join(', ') | upper }} ({{ item.data.date | formatDate("YYYY") }}){% else %}({{ item.data.date | formatDate("YYYY") }}){% endif %}</div>
             {% endfor %}
           </div>
         {% endif %}


### PR DESCRIPTION
Check that categories array has length before calling join filter. Prevents TypeError when categories is null (from YAML `categories:` without value).