### PR TITLE
Fix mobile header image cropping and background overflow

### DIFF
--- a/home.njk
+++ b/home.njk
@@ -66,6 +66,7 @@ permalink: "/index.html"
     .project-header {
       margin-left: 0;
       margin-right: 0;
+      height: auto;
     }
 
     .project-header .grid {
@@ -76,6 +77,18 @@ permalink: "/index.html"
       padding: 0;
       margin: 0;
       overflow: hidden;
+      height: 45vw;
+    }
+
+    .project-header picture.header-image {
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .project-header picture.header-image img {
+      height: 100%;
+      object-fit: cover;
+      object-position: center top;
     }
 
     .project-header .grid__item--span-2-left,


### PR DESCRIPTION
On mobile, the header image now uses a constrained height (45vw) with object-fit: cover to avoid excessive cropping, and the header container uses height: auto so the blue background expands to fit all stacked content.