### PR TITLE
Fix portrait header image not rendering on project pages

### DIFF
--- a/_includes/layouts/project.njk
+++ b/_includes/layouts/project.njk
@@ -550,6 +550,7 @@ section: project
     .project-header.is-portrait-header {
       overflow: visible;
       margin-bottom: 0;
+      position: relative;
     }
 
     /* Image container: absolutely positioned, left viewport edge to 2-col midpoint,


### PR DESCRIPTION
Missing `position: relative` on `.project-header.is-portrait-header` caused the absolutely-positioned image container to escape its intended anchor, making portrait header images invisible.