### PR TITLE
Reorganize admin page: simpler table, structured panel, sticky header fix

### DIFF
--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -183,7 +183,7 @@ body {
 
 /* Table */
 .admin-table-wrap {
-  overflow-x: auto;
+  overflow-x: visible;
 }
 .admin-table {
   width: 100%;

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -27,40 +27,130 @@ body {
   background: var(--admin-bg);
 }
 
-/* Login */
+/* Login — 5 columns × 5 rows grid */
 .login-screen {
   display: none;
-  align-items: center;
-  justify-content: center;
   min-height: 100vh;
 }
-.login-screen:not([hidden]) {
-  display: flex;
+.login-screen[hidden] {
+  display: none;
 }
-.login-box {
-  background: var(--admin-surface);
-  border: 1px solid var(--admin-border);
-  padding: 2rem;
-  max-width: 360px;
+.login-screen:not([hidden]) {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr 1fr;
+  grid-template-rows: 1fr auto auto auto 1fr;
+}
+
+/* Dashed vertical column separators — full-height lines spanning all rows */
+.login-screen:not([hidden])::before,
+.login-screen:not([hidden])::after,
+.login-col-line {
+  grid-row: 1 / -1;
+  border-right: 1px dashed var(--admin-border);
+  pointer-events: none;
+}
+.login-screen:not([hidden])::before { content: ''; grid-column: 1; }
+.login-screen:not([hidden])::after  { content: ''; grid-column: 2; }
+.login-col-line { grid-column: 3; position: relative; z-index: 1; }
+.login-row-line {
+  grid-column: 1 / -1;
+  height: 0;
+  border-top: 1px dashed var(--admin-border);
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+}
+.login-row-line--top     { grid-row: 2; align-self: start; }
+.login-row-line--bottom  { grid-row: 5; align-self: start; }
+.login-row-line--heading  { grid-column: 3; grid-row: 3; align-self: start; }
+.login-row-line--password { grid-column: 3; grid-row: 4; align-self: start; }
+
+
+/* Logo cell: col 2, rows 2–4 */
+.login-cell--logo {
+  grid-column: 2;
+  grid-row: 2 / 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+.login-cell--logo img {
+  width: 72px;
+  height: auto;
+}
+
+/* Form cells: col 3 */
+.login-cell--heading {
+  grid-column: 3;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+}
+.login-cell--heading h1 {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--admin-primary);
+}
+
+.login-cell--password {
+  grid-column: 3;
+  grid-row: 3;
+  display: flex;
+  align-items: center;
+}
+#login-form {
   width: 100%;
 }
-.login-box h1 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-.login-box p { color: var(--admin-text-muted); margin-bottom: 1rem; }
-.login-box form { display: flex; flex-direction: column; gap: 0.75rem; }
-.login-box input {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--admin-border);
+#login-password {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border: none;
+  background: transparent;
   font-size: 13px;
   font-family: inherit;
+  color: var(--admin-text-muted);
+  letter-spacing: 0.05em;
 }
-.login-box input:focus { outline: 2px solid var(--admin-primary); outline-offset: -1px; }
-.error { color: var(--admin-danger); font-size: 12px; }
+#login-password:focus {
+  outline: none;
+  color: var(--admin-text);
+}
+#login-password::placeholder {
+  text-transform: uppercase;
+}
+
+.login-cell--button {
+  grid-column: 3;
+  grid-row: 4;
+  display: flex;
+  align-items: stretch;
+}
+.login-cell--button button {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border: none;
+  background: var(--admin-tag-bg);
+  font-size: 0.8rem;
+  font-family: inherit;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--admin-primary);
+  cursor: pointer;
+}
+.login-cell--button button:hover {
+  filter: brightness(0.95);
+}
+
+.error {
+  color: var(--admin-danger);
+  font-size: 12px;
+  padding: 0.25rem 1rem;
+}
 
 /* Buttons */
 .btn {
@@ -90,6 +180,34 @@ body {
 .btn--small { padding: 0.25rem 0.5rem; font-size: 11px; }
 
 .admin-screen[hidden] { display: none; }
+.admin-screen:not([hidden]) {
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
+}
+
+/* Vertical dashed edge lines at content boundaries */
+.admin-screen:not([hidden])::before,
+.admin-screen:not([hidden])::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  --dash-size: 4px;
+  --dash-gap: 4px;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--admin-border) 0,
+    var(--admin-border) var(--dash-size),
+    transparent var(--dash-size),
+    transparent calc(var(--dash-size) + var(--dash-gap))
+  );
+  pointer-events: none;
+  z-index: 200;
+}
+.admin-screen:not([hidden])::before { left: 0; }
+.admin-screen:not([hidden])::after  { right: 0; }
 
 /* Header */
 .admin-header {
@@ -97,12 +215,24 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--admin-border);
-  background: var(--admin-surface);
+  border-bottom: none;
+  background: transparent;
   position: sticky;
   top: 0;
   z-index: 100;
   height: var(--admin-header-height);
+  overflow: visible;
+}
+.admin-header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  background: var(--admin-surface);
+  border-bottom: 1px solid var(--admin-border);
+  z-index: -1;
 }
 .admin-header h1 {
   font-size: 0.85rem;
@@ -123,18 +253,103 @@ body {
 
 /* Toolbar */
 .admin-toolbar {
-  padding: 0.5rem 1rem;
-  border-bottom: 1px dashed var(--admin-border);
-  background: var(--admin-surface);
-  display: flex;
-  flex-wrap: wrap;
+  padding: 0.5rem;
+  border-bottom: none;
+  background: transparent;
+  display: grid;
+  grid-template-columns: 2fr 10fr 6fr 6fr;
   gap: 0.5rem;
-  align-items: center;
+  align-items: start;
   position: sticky;
   top: var(--admin-header-height);
   z-index: 99;
+  overflow: visible;
 }
-.admin-toolbar__search { flex: 0 0 250px; }
+.admin-toolbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  background: var(--admin-surface);
+  border-bottom: 1px dashed var(--admin-border);
+  z-index: -1;
+}
+/* Draft filter dropdown */
+.admin-dropdown {
+  position: relative;
+}
+.admin-dropdown__button {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--admin-border);
+  background: var(--admin-surface);
+  color: var(--admin-text);
+  font-size: 12px;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  text-align: left;
+}
+.admin-dropdown__button:hover { opacity: 0.7; }
+.admin-dropdown__chevron {
+  margin-left: auto;
+  transition: transform 200ms ease;
+  flex-shrink: 0;
+}
+.admin-dropdown.is-open .admin-dropdown__chevron {
+  transform: rotate(180deg);
+}
+.admin-dropdown__drawer {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  background: var(--admin-surface);
+  border-left: 1px solid var(--admin-border);
+  border-right: 1px solid var(--admin-border);
+  border-bottom: 1px solid transparent;
+  clip-path: inset(0 0 100% 0);
+  transition: clip-path 250ms ease, visibility 250ms ease;
+  pointer-events: none;
+  visibility: hidden;
+}
+.admin-dropdown.is-open .admin-dropdown__drawer {
+  clip-path: inset(0 0 0 0);
+  transition: clip-path 250ms ease;
+  pointer-events: auto;
+  visibility: visible;
+  border-bottom-color: var(--admin-primary);
+}
+.admin-dropdown__item {
+  display: flex;
+  align-items: center;
+  padding: 0.35rem 0.5rem;
+  background: var(--admin-surface);
+  border: none;
+  border-bottom: 1px dashed var(--admin-border);
+  color: var(--admin-text);
+  font-size: 12px;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  text-align: left;
+}
+.admin-dropdown__item:last-child { border-bottom: none; }
+.admin-dropdown__item:hover { background: var(--admin-highlight); }
+.admin-dropdown__item.is-selected { color: var(--admin-primary); }
+.admin-dropdown__item::before { content: ''; display: inline-block; width: 0.7rem; margin-right: 0.35rem; flex-shrink: 0; }
+.admin-dropdown__item.is-selected::before { content: '✓'; }
+.admin-dropdown:not(.is-open) .admin-dropdown__item { border-bottom-color: transparent; }
 .admin-toolbar__search input {
   width: 100%;
   padding: 0.35rem 0.5rem;
@@ -143,10 +358,20 @@ body {
   font-family: inherit;
 }
 .admin-toolbar__search input:focus { outline: 2px solid var(--admin-primary); outline-offset: -1px; }
-.admin-toolbar__filters {
-  display: flex;
-  flex-wrap: wrap;
+.admin-toolbar__categories {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
   gap: 0.25rem;
+}
+.admin-toolbar__categories .admin-dropdown {
+  grid-column: 1;
+}
+.admin-toolbar__categories #manage-btn {
+  grid-column: 2;
+  grid-row: 1 / 3;
+  align-self: stretch;
+  height: 100%;
 }
 .filter-chip {
   display: inline-flex;
@@ -167,17 +392,10 @@ body {
 }
 .filter-chip input { display: none; }
 
-.admin-toolbar__draft-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-}
-
 .admin-toolbar__bulk {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-left: auto;
   font-size: 12px;
 }
 
@@ -193,8 +411,23 @@ body {
 .admin-table th, .admin-table td {
   padding: 0.4rem 0.5rem;
   text-align: left;
-  border-bottom: 1px dashed var(--admin-border);
+  border-bottom: none;
   vertical-align: top;
+}
+/* Full-viewport-width row dividers via ::after on the last td */
+.admin-table tbody td:last-child {
+  position: relative;
+}
+.admin-table tbody td:last-child::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin-left: calc(-100vw + 100%);
+  width: 300vw;
+  height: 0;
+  border-bottom: 1px dashed var(--admin-border);
+  pointer-events: none;
 }
 .admin-table th {
   font-size: 11px;
@@ -207,22 +440,51 @@ body {
   top: calc(var(--admin-header-height) + var(--admin-toolbar-actual-height, var(--admin-toolbar-height)));
   z-index: 98;
   border-bottom: none;
-  box-shadow: inset 0 -2px 0 var(--admin-primary);
 }
 .admin-table th.sortable { cursor: pointer; }
 .admin-table th.sortable:hover { color: var(--admin-text); }
 .admin-table th.sort-asc::after { content: ' \u25B2'; font-size: 9px; }
 .admin-table th.sort-desc::after { content: ' \u25BC'; font-size: 9px; }
 
+/* Full-bleed thick bottom border below thead */
+.admin-table thead th:last-child::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin-left: calc(-100vw + 100%);
+  width: 300vw;
+  height: 0;
+  border-bottom: 2px solid var(--admin-primary);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Full-height vertical column dividers — anchored to th, extend full page height */
+.admin-table thead th:not(:last-child) {
+  overflow: visible;
+}
+.admin-table thead th:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 300vh;
+  border-right: 1px dashed var(--admin-border);
+  pointer-events: none;
+  z-index: 1;
+}
+
 .admin-table tr:hover { background: var(--admin-tag-bg); }
 .admin-table tr.is-modified { background: var(--admin-highlight); border-left: 2px solid var(--admin-primary); }
 .admin-table tr.is-selected { background: var(--admin-tag-bg); }
 
-.col-select { width: 36px; text-align: center; }
-.col-title { width: auto; }
-.col-categories { width: 260px; }
-.col-type { width: 90px; }
-.col-date { width: 90px; }
+.col-select { width: 4.17%; text-align: center; vertical-align: middle; }   /* 1fr */
+.col-title { width: 41.67%; }                        /* 10fr */
+.col-categories { width: 25%; }                      /* 6fr */
+.col-type { width: 8.33%; }                          /* 2fr */
+.col-date { width: 8.33%; }                          /* 2fr */
 
 /* Empty cell placeholder */
 .cell-empty { color: var(--admin-text-muted); font-size: 11px; }
@@ -472,8 +734,8 @@ body {
 .btn--danger-solid:hover { background: #a93226; }
 
 /* Table columns */
-.col-draft { width: 48px; text-align: center; }
-.col-actions { width: 90px; white-space: nowrap; text-align: right; }
+.col-draft { width: 4.17%; text-align: center; }     /* 1fr */
+.col-actions { width: 8.33%; white-space: nowrap; text-align: right; } /* 2fr */
 
 /* Draft toggle */
 .draft-toggle {
@@ -500,7 +762,8 @@ body {
 .admin-table tr.is-new-row { background: var(--admin-tag-bg); }
 
 /* Action buttons in row */
-.action-edit-btn, .action-delete-btn { margin-left: 3px; }
+.action-edit-btn, .action-delete-btn { display: block; width: 100%; margin-bottom: 2px; }
+.action-delete-btn { margin-bottom: 0; }
 
 /* Edit panel */
 .edit-panel {

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -206,7 +206,8 @@ body {
   position: sticky;
   top: calc(var(--admin-header-height) + var(--admin-toolbar-actual-height, var(--admin-toolbar-height)));
   z-index: 98;
-  border-bottom: 2px solid var(--admin-primary);
+  border-bottom: none;
+  box-shadow: inset 0 -2px 0 var(--admin-primary);
 }
 .admin-table th.sortable { cursor: pointer; }
 .admin-table th.sortable:hover { color: var(--admin-text); }

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -2,27 +2,27 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --admin-bg: #fafafa;
-  --admin-surface: #fff;
-  --admin-border: #e0e0e0;
-  --admin-text: #1a1a1a;
-  --admin-text-muted: #666;
-  --admin-primary: #1a1a1a;
-  --admin-primary-hover: #333;
-  --admin-danger: #c0392b;
-  --admin-tag-bg: #f0f0f0;
-  --admin-tag-border: #ccc;
-  --admin-highlight: #fffde7;
-  --admin-font: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --admin-mono: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+  --admin-bg:            #ffffff;
+  --admin-surface:       #ffffff;
+  --admin-border:        #001489;
+  --admin-text:          #101010;
+  --admin-text-muted:    #5a6a8a;
+  --admin-primary:       #001489;
+  --admin-primary-hover: #2D4BA8;
+  --admin-danger:        #c0392b;
+  --admin-tag-bg:        #EAEEFD;
+  --admin-tag-border:    #001489;
+  --admin-highlight:     #EAEEFD;
+  --admin-font:         'Overpass Mono', 'SF Mono', 'Fira Code', monospace;
+  --admin-mono:         'Overpass Mono', 'SF Mono', 'Fira Code', monospace;
   --admin-header-height: 42px;
   --admin-toolbar-height: 41px;
 }
 
 body {
   font-family: var(--admin-font);
-  font-size: 13px;
-  line-height: 1.4;
+  font-size: 0.85rem;
+  line-height: 1.5;
   color: var(--admin-text);
   background: var(--admin-bg);
 }
@@ -76,7 +76,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
-.btn:hover { background: #f0f0f0; }
+.btn:hover { background: var(--admin-tag-bg); }
 .btn--primary {
   background: var(--admin-primary);
   color: #fff;
@@ -124,7 +124,7 @@ body {
 /* Toolbar */
 .admin-toolbar {
   padding: 0.5rem 1rem;
-  border-bottom: 1px solid var(--admin-border);
+  border-bottom: 1px dashed var(--admin-border);
   background: var(--admin-surface);
   display: flex;
   flex-wrap: wrap;
@@ -193,7 +193,7 @@ body {
 .admin-table th, .admin-table td {
   padding: 0.4rem 0.5rem;
   text-align: left;
-  border-bottom: 1px solid var(--admin-border);
+  border-bottom: 1px dashed var(--admin-border);
   vertical-align: top;
 }
 .admin-table th {
@@ -213,9 +213,9 @@ body {
 .admin-table th.sort-asc::after { content: ' \u25B2'; font-size: 9px; }
 .admin-table th.sort-desc::after { content: ' \u25BC'; font-size: 9px; }
 
-.admin-table tr:hover { background: #f8f8f8; }
-.admin-table tr.is-modified { background: var(--admin-highlight); }
-.admin-table tr.is-selected { background: #e8f0fe; }
+.admin-table tr:hover { background: var(--admin-tag-bg); }
+.admin-table tr.is-modified { background: var(--admin-highlight); border-left: 2px solid var(--admin-primary); }
+.admin-table tr.is-selected { background: var(--admin-tag-bg); }
 
 .col-select { width: 36px; text-align: center; }
 .col-title { width: auto; }
@@ -307,8 +307,8 @@ body {
   font-size: 11px;
   text-transform: uppercase;
 }
-.type-dropdown-item:hover { background: #f0f0f0; }
-.type-dropdown-item.is-active { font-weight: 600; background: #e8f0fe; }
+.type-dropdown-item:hover { background: var(--admin-tag-bg); }
+.type-dropdown-item.is-active { font-weight: 600; background: var(--admin-tag-bg); }
 .type-dropdown-item.is-new { font-style: italic; color: var(--admin-primary); text-transform: none; }
 
 /* Category dropdown */
@@ -340,7 +340,7 @@ body {
   font-size: 12px;
   text-transform: uppercase;
 }
-.category-dropdown li:hover { background: #f0f0f0; }
+.category-dropdown li:hover { background: var(--admin-tag-bg); }
 .category-dropdown li.is-new { font-style: italic; color: var(--admin-primary); }
 .category-dropdown li.is-new::before { content: '+ Create '; font-style: normal; }
 
@@ -390,7 +390,7 @@ body {
   font-size: 12px;
   text-transform: uppercase;
 }
-.modal-content li:hover { background: #f0f0f0; }
+.modal-content li:hover { background: var(--admin-tag-bg); }
 .modal-content li.is-new::before { content: '+ Create '; font-style: italic; }
 .modal-actions { display: flex; gap: 0.5rem; justify-content: flex-end; }
 
@@ -486,7 +486,7 @@ body {
   height: 10px;
   border-radius: 50%;
   border: 1px solid var(--admin-border);
-  background: #e0e0e0;
+  background: var(--admin-tag-bg);
   display: inline-block;
   transition: background 0.15s, border-color 0.15s;
 }
@@ -496,7 +496,7 @@ body {
 }
 
 /* New row highlight */
-.admin-table tr.is-new-row { background: #f0f7ff; }
+.admin-table tr.is-new-row { background: var(--admin-tag-bg); }
 
 /* Action buttons in row */
 .action-edit-btn, .action-delete-btn { margin-left: 3px; }
@@ -602,7 +602,7 @@ body {
 }
 .ep-body-preview p { margin-bottom: 0.4rem; }
 .ep-body-preview ul, .ep-body-preview ol { padding-left: 1.2rem; margin-bottom: 0.4rem; }
-.ep-body-preview code { font-family: var(--admin-mono); font-size: 11px; background: #f0f0f0; padding: 0 3px; }
+.ep-body-preview code { font-family: var(--admin-mono); font-size: 11px; background: var(--admin-tag-bg); padding: 0 3px; }
 
 /* Category suggestions in panel (uppercase like categories) */
 #ep-category-suggestions li { text-transform: uppercase; }
@@ -703,7 +703,7 @@ body {
   font-size: 12px;
   font-family: var(--admin-mono);
 }
-.tag-suggestions li:hover { background: #f0f0f0; }
+.tag-suggestions li:hover { background: var(--admin-tag-bg); }
 
 /* Edit panel backdrop */
 .edit-panel-backdrop {

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -15,6 +15,8 @@
   --admin-highlight: #fffde7;
   --admin-font: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --admin-mono: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+  --admin-header-height: 42px;
+  --admin-toolbar-height: 41px;
 }
 
 body {
@@ -100,6 +102,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 100;
+  height: var(--admin-header-height);
 }
 .admin-header h1 {
   font-size: 0.85rem;
@@ -128,7 +131,7 @@ body {
   gap: 0.5rem;
   align-items: center;
   position: sticky;
-  top: 42px;
+  top: var(--admin-header-height);
   z-index: 99;
 }
 .admin-toolbar__search { flex: 0 0 250px; }
@@ -164,6 +167,12 @@ body {
 }
 .filter-chip input { display: none; }
 
+.admin-toolbar__draft-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
 .admin-toolbar__bulk {
   display: flex;
   align-items: center;
@@ -195,7 +204,7 @@ body {
   color: var(--admin-text-muted);
   background: var(--admin-surface);
   position: sticky;
-  top: 85px;
+  top: calc(var(--admin-header-height) + var(--admin-toolbar-actual-height, var(--admin-toolbar-height)));
   z-index: 98;
   border-bottom: 2px solid var(--admin-primary);
 }
@@ -209,19 +218,13 @@ body {
 .admin-table tr.is-selected { background: #e8f0fe; }
 
 .col-select { width: 36px; text-align: center; }
-.col-slug { width: 180px; }
 .col-title { width: auto; }
-.col-categories { width: 300px; }
-.col-type { width: 100px; }
+.col-categories { width: 260px; }
+.col-type { width: 90px; }
 .col-date { width: 90px; }
 
-/* Slug cell */
-.cell-slug {
-  font-family: var(--admin-mono);
-  font-size: 11px;
-  color: var(--admin-text-muted);
-  word-break: break-all;
-}
+/* Empty cell placeholder */
+.cell-empty { color: var(--admin-text-muted); font-size: 11px; }
 
 /* Category tags */
 .category-cell {
@@ -281,9 +284,7 @@ body {
 .type-value:hover { border-color: var(--admin-border); }
 
 .type-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
+  position: fixed;
   background: var(--admin-surface);
   border: 1px solid var(--admin-border);
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
@@ -506,7 +507,7 @@ body {
   top: 0;
   right: 0;
   bottom: 0;
-  width: 360px;
+  width: 420px;
   background: var(--admin-surface);
   border-left: 1px solid var(--admin-border);
   z-index: 250;
@@ -540,8 +541,72 @@ body {
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0;
 }
+
+/* Edit panel sections */
+.ep-section {
+  border-top: 1px solid var(--admin-border);
+  padding: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.ep-section:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+.ep-section__label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--admin-text-muted);
+}
+.ep-section__label--row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* Slug field (read-only for existing entries) */
+#ep-slug[readonly] {
+  background: var(--admin-bg);
+  color: var(--admin-text-muted);
+  font-family: var(--admin-mono);
+  font-size: 11px;
+}
+
+/* Type selector in panel */
+.ep-type-display {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Body preview */
+.ep-body-preview {
+  border: 1px solid var(--admin-border);
+  padding: 0.75rem;
+  font-size: 12px;
+  line-height: 1.6;
+  min-height: 80px;
+  overflow-y: auto;
+  max-height: 300px;
+  background: var(--admin-bg);
+}
+.ep-body-preview h1, .ep-body-preview h2, .ep-body-preview h3 {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+.ep-body-preview p { margin-bottom: 0.4rem; }
+.ep-body-preview ul, .ep-body-preview ol { padding-left: 1.2rem; margin-bottom: 0.4rem; }
+.ep-body-preview code { font-family: var(--admin-mono); font-size: 11px; background: #f0f0f0; padding: 0 3px; }
+
+/* Category suggestions in panel (uppercase like categories) */
+#ep-category-suggestions li { text-transform: uppercase; }
+#ep-category-suggestions li.is-new { font-style: italic; text-transform: none; color: var(--admin-primary); }
 
 .edit-panel__footer {
   display: flex;

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -54,6 +54,7 @@
   var tbody = document.getElementById('entries-tbody');
   var searchInput = document.getElementById('search-input');
   var typeFiltersEl = document.getElementById('type-filters');
+  var draftFiltersEl = document.getElementById('draft-filters');
   var selectAllCb = document.getElementById('select-all');
   var bulkActions = document.getElementById('bulk-actions');
   var selectedCountEl = document.getElementById('selected-count');
@@ -61,9 +62,6 @@
   var changeCountEl = document.getElementById('change-count');
   var logoutBtn = document.getElementById('logout-btn');
   var newEntryBtn = document.getElementById('new-entry-btn');
-  var categoryDropdown = document.getElementById('category-dropdown');
-  var categorySearchInput = document.getElementById('category-search');
-  var categoryList = document.getElementById('category-list');
   var bulkModal = document.getElementById('bulk-modal');
   var bulkModalTitle = document.getElementById('bulk-modal-title');
   var bulkCategoryInput = document.getElementById('bulk-category-input');
@@ -111,6 +109,15 @@
   var epRelatedProjectInput = document.getElementById('ep-related-project-input');
   var epRelatedProjectSuggestions = document.getElementById('ep-related-project-suggestions');
   var epBody = document.getElementById('ep-body');
+  var epSlug = document.getElementById('ep-slug');
+  var epDraft = document.getElementById('ep-draft');
+  var epTypeValue = document.getElementById('ep-type-value');
+  var epTypeChange = document.getElementById('ep-type-change');
+  var epCategoriesTags = document.getElementById('ep-categories-tags');
+  var epCategoryInput = document.getElementById('ep-category-input');
+  var epCategorySuggestions = document.getElementById('ep-category-suggestions');
+  var epPreviewToggle = document.getElementById('ep-preview-toggle');
+  var epBodyPreview = document.getElementById('ep-body-preview');
 
   // ---- Auth ----
   function showLogin() {
@@ -126,9 +133,22 @@
     if (!adminInitialized) {
       adminInitialized = true;
       buildTypeFilters();
+      // Track actual toolbar height for sticky table header
+      var adminToolbar = document.querySelector('.admin-toolbar');
+      var ro = new ResizeObserver(function(entries) {
+        var h = Math.ceil(entries[0].contentRect.height);
+        document.documentElement.style.setProperty('--admin-toolbar-actual-height', h + 'px');
+      });
+      ro.observe(adminToolbar);
     }
     renderTable();
   }
+
+  // ---- Draft filter ----
+  draftFiltersEl.addEventListener('change', function(e) {
+    draftFilter = e.target.value;
+    renderTable();
+  });
 
   sessionStorage.removeItem('admin_token');
 
@@ -380,27 +400,28 @@
       // Draft toggle
       html += '<td class="col-draft"><label class="draft-toggle"><input type="checkbox" class="draft-cb"' + (entry.draft ? ' checked' : '') + '><span class="draft-dot"></span></label></td>';
 
-      // Slug
-      html += '<td class="col-slug"><span class="cell-slug">' + escHtml(entry.slug) + '</span></td>';
-
       // Title
-      html += '<td class="col-title">' + escHtml(entry.title || '') + '</td>';
+      html += '<td class="col-title">' + escHtml(entry.title || entry.slug || '') + '</td>';
 
-      // Categories
+      // Categories (read-only)
       html += '<td class="col-categories"><div class="category-cell">';
-      (entry.categories || []).forEach(function(cat) {
-        html += '<span class="cat-tag">' + escHtml(cat) + '<span class="cat-tag__remove" data-cat="' + escHtml(cat) + '">&times;</span></span>';
-      });
-      html += '<button class="cat-add-btn" data-action="add-category">+</button>';
+      if ((entry.categories || []).length === 0) {
+        html += '<span class="cell-empty">&mdash;</span>';
+      } else {
+        (entry.categories || []).forEach(function(cat) {
+          html += '<span class="cat-tag">' + escHtml(cat) + '</span>';
+        });
+      }
       html += '</div></td>';
 
-      // Type
-      html += '<td class="col-type"><div class="type-cell">';
+      // Type (read-only)
+      html += '<td class="col-type">';
       if (entry.entryType) {
-        html += '<span class="cat-tag type-tag">' + escHtml(entry.entryType.toUpperCase()) + '<span class="cat-tag__remove type-tag__change" data-action="edit-type" title="Change type">\u2715</span></span>';
+        html += '<span class="cat-tag">' + escHtml(entry.entryType.toUpperCase()) + '</span>';
+      } else {
+        html += '<span class="cell-empty">&mdash;</span>';
       }
-      html += '<button class="cat-add-btn" data-action="edit-type">+</button>';
-      html += '</div></td>';
+      html += '</td>';
 
       // Date
       html += '<td class="col-date">' + escHtml(toDateInputValue(entry.date)) + '</td>';
@@ -435,8 +456,6 @@
   }
 
   // ---- Table event delegation ----
-  var activeCategoryPath = null;
-
   tbody.addEventListener('change', function(e) {
     var row = e.target.closest('tr');
     if (!row) return;
@@ -467,36 +486,6 @@
     var row = e.target.closest('tr');
     if (!row) return;
     var path = row.dataset.path;
-
-    // Remove category tag
-    if (e.target.classList.contains('cat-tag__remove')) {
-      var cat = e.target.dataset.cat;
-      var entry = findEntry(path);
-      if (entry) {
-        entry.categories = (entry.categories || []).filter(function(c) { return c !== cat; });
-        updateChanges();
-        renderTable();
-      }
-      return;
-    }
-
-    // Add category button
-    if (e.target.dataset.action === 'add-category') {
-      e.stopPropagation();
-      activeCategoryPath = path;
-      showCategoryDropdown(e.target);
-      return;
-    }
-
-    // Edit type (click on tag × button, tag itself, or + button)
-    if (e.target.dataset.action === 'edit-type') {
-      e.stopPropagation();
-      // Find the type-cell to anchor the dropdown
-      var typeCell = e.target.closest('.type-cell');
-      var anchor = typeCell ? typeCell.querySelector('.cat-add-btn') : e.target;
-      showTypeDropdown(anchor || e.target, path);
-      return;
-    }
 
     // Open edit panel
     if (e.target.dataset.action === 'open-edit') {
@@ -583,87 +572,16 @@
     pendingDeletePath = null;
   });
 
-  // ---- Category dropdown ----
-  function showCategoryDropdown(anchor) {
-    var rect = anchor.getBoundingClientRect();
-    categoryDropdown.style.top = (rect.bottom + window.scrollY) + 'px';
-    categoryDropdown.style.left = (rect.left + window.scrollX) + 'px';
-    categoryDropdown.hidden = false;
-    categorySearchInput.value = '';
-    renderCategoryList('');
-    categorySearchInput.focus();
-  }
-
-  function hideCategoryDropdown() {
-    categoryDropdown.hidden = true;
-    activeCategoryPath = null;
-  }
-
-  categorySearchInput.addEventListener('input', function() {
-    renderCategoryList(this.value.trim());
-  });
-
-  categorySearchInput.addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      var val = this.value.trim().toUpperCase();
-      if (val) addCategoryToEntry(activeCategoryPath, val);
-    }
-    if (e.key === 'Escape') hideCategoryDropdown();
-  });
-
-  function renderCategoryList(query) {
-    var upper = query.toUpperCase();
-    var entry = findEntry(activeCategoryPath);
-    var current = entry ? (entry.categories || []) : [];
-
-    var filtered = canonicalCategories.filter(function(c) {
-      if (current.indexOf(c) !== -1) return false;
-      if (!upper) return true;
-      return c.indexOf(upper) !== -1;
-    });
-
-    var html = '';
-    filtered.forEach(function(c) {
-      html += '<li data-value="' + escHtml(c) + '">' + escHtml(c) + '</li>';
-    });
-
-    if (upper && canonicalCategories.indexOf(upper) === -1) {
-      html += '<li class="is-new" data-value="' + escHtml(upper) + '">' + escHtml(upper) + '</li>';
-    }
-
-    categoryList.innerHTML = html;
-  }
-
-  categoryList.addEventListener('click', function(e) {
-    var li = e.target.closest('li');
-    if (!li) return;
-    addCategoryToEntry(activeCategoryPath, li.dataset.value);
-  });
-
-  function addCategoryToEntry(filePath, category) {
-    var entry = findEntry(filePath);
-    if (!entry) return;
-    if (!entry.categories) entry.categories = [];
-    if (entry.categories.indexOf(category) !== -1) return;
-    entry.categories.push(category);
-    if (canonicalCategories.indexOf(category) === -1) {
-      canonicalCategories.push(category);
-      canonicalCategories.sort();
-    }
-    hideCategoryDropdown();
-    updateChanges();
-    renderTable();
-  }
-
   document.addEventListener('click', function(e) {
-    if (!categoryDropdown.hidden && !categoryDropdown.contains(e.target) && !e.target.classList.contains('cat-add-btn')) {
-      hideCategoryDropdown();
-    }
     document.querySelectorAll('.type-dropdown').forEach(function(dd) { dd.remove(); });
     if (epRelatedProjectSuggestions && !epRelatedProjectSuggestions.hidden) {
       if (!epRelatedProjectInput.contains(e.target) && !epRelatedProjectSuggestions.contains(e.target)) {
         epRelatedProjectSuggestions.hidden = true;
+      }
+    }
+    if (epCategorySuggestions && !epCategorySuggestions.hidden) {
+      if (!epCategoryInput.contains(e.target) && !epCategorySuggestions.contains(e.target)) {
+        epCategorySuggestions.hidden = true;
       }
     }
   });
@@ -711,6 +629,13 @@
         entry.filePath = newPath;
       }
       entry.entryType = typeName;
+      // Sync panel if open
+      if (!editPanel.hidden) {
+        epTypeValue.textContent = typeName.toUpperCase();
+        var proj = isProject(typeName);
+        document.querySelectorAll('.project-only').forEach(function(el) { el.hidden = !proj; });
+        document.querySelectorAll('.non-project-only').forEach(function(el) { el.hidden = proj; });
+      }
       updateChanges();
       renderTable();
       dd.remove();
@@ -747,9 +672,20 @@
     });
 
     renderTypeList('');
-    anchor.closest('.type-cell').appendChild(dd);
+    // Position dropdown relative to anchor
+    var rect = anchor.getBoundingClientRect();
+    dd.style.position = 'fixed';
+    dd.style.top = rect.bottom + 'px';
+    dd.style.left = rect.left + 'px';
+    document.body.appendChild(dd);
     input.focus();
   }
+
+  // ---- Type change button in panel ----
+  epTypeChange.addEventListener('click', function(e) {
+    e.stopPropagation();
+    if (activeEditPath) showTypeDropdown(epTypeChange, activeEditPath);
+  });
 
   // ---- Edit panel ----
   function openEditPanel(filePath) {
@@ -760,10 +696,17 @@
     editPanelTitle.textContent = entry._isNew ? 'New Entry' : 'Edit: ' + (entry.title || entry.slug);
 
     // Populate fields
+    epSlug.value = entry.slug || '';
+    epSlug.readOnly = !entry._isNew;
+    epDraft.checked = !!entry.draft;
+    epTypeValue.textContent = (entry.entryType || '').toUpperCase();
     epTitle.value = entry.title || '';
     epSubtitle.value = entry.subtitle || '';
     epDescription.value = entry.description || '';
     epDate.value = toDateInputValue(entry.date);
+    renderPanelCategoryTags(entry.categories || []);
+    epCategoryInput.value = '';
+    epCategorySuggestions.hidden = true;
     epLink.value = entry.link || '';
     epPosition.value = entry.position != null ? entry.position : '';
     epYear.value = entry.year || '';
@@ -773,11 +716,16 @@
     epFeaturedPositionGroup.hidden = !entry.featured;
     epFeaturedPosition.value = entry.featuredPosition != null ? entry.featuredPosition : '';
     epBody.value = entry.body || '';
+    epBodyPreview.hidden = true;
+    epBody.hidden = false;
+    epPreviewToggle.textContent = 'Preview';
 
     // Show/hide project-only and non-project fields
     var proj = isProject(entry.entryType);
     document.querySelectorAll('.project-only').forEach(function(el) { el.hidden = !proj; });
     document.querySelectorAll('.non-project-only').forEach(function(el) { el.hidden = proj; });
+    // Featured position always starts hidden, shown by featured toggle
+    epFeaturedPositionGroup.hidden = !entry.featured;
 
     // Collaborators
     renderCollaboratorsList(entry.collaborators || []);
@@ -811,6 +759,8 @@
     var entry = findEntry(activeEditPath);
     if (!entry) return;
 
+    entry.draft = epDraft.checked;
+    entry.categories = getPanelCategories();
     entry.title = epTitle.value.trim();
     entry.subtitle = epSubtitle.value.trim();
     entry.description = epDescription.value.trim();
@@ -824,16 +774,18 @@
     entry.featuredPosition = epFeatured.checked && epFeaturedPosition.value !== '' ? Number(epFeaturedPosition.value) : null;
     entry.body = epBody.value;
 
-    // Update slug for new entries based on title
-    if (entry._isNew && entry.title) {
+    // Update slug for new entries
+    if (entry._isNew) {
       var oldPath = entry.filePath;
-      var newSlug = generateSlug(entry.title);
+      var manualSlug = epSlug.value.trim();
+      var newSlug = manualSlug || generateSlug(entry.title || 'new-entry');
       entry.slug = newSlug;
       var folder = typeFolder(entry.entryType);
       var newPath = 'entries/' + folder + '/' + newSlug + '/' + newSlug + '.md';
       entry.filePath = newPath;
       activeEditPath = newPath;
       selectedPaths.delete(oldPath);
+      epSlug.value = newSlug;
     }
 
     // Update panel title
@@ -890,6 +842,75 @@
       entry.collaborators.splice(idx, 1);
       renderCollaboratorsList(entry.collaborators);
     }
+  });
+
+  // ---- Panel category editor ----
+  function renderPanelCategoryTags(categories) {
+    epCategoriesTags.innerHTML = '';
+    (categories || []).forEach(function(cat) {
+      var tag = document.createElement('span');
+      tag.className = 'cat-tag';
+      tag.innerHTML = escHtml(cat) + '<span class="cat-tag__remove" data-cat="' + escHtml(cat) + '">&times;</span>';
+      epCategoriesTags.appendChild(tag);
+    });
+  }
+
+  function getPanelCategories() {
+    var cats = [];
+    epCategoriesTags.querySelectorAll('.cat-tag__remove').forEach(function(el) {
+      cats.push(el.dataset.cat);
+    });
+    return cats;
+  }
+
+  epCategoriesTags.addEventListener('click', function(e) {
+    if (e.target.classList.contains('cat-tag__remove')) {
+      e.target.closest('.cat-tag').remove();
+    }
+  });
+
+  epCategoryInput.addEventListener('input', function() {
+    var query = this.value.trim().toUpperCase();
+    if (!query) { epCategorySuggestions.hidden = true; return; }
+    var current = getPanelCategories();
+    var matches = canonicalCategories.filter(function(c) {
+      return current.indexOf(c) === -1 && c.indexOf(query) !== -1;
+    });
+    var html = matches.map(function(c) {
+      return '<li data-value="' + escHtml(c) + '">' + escHtml(c) + '</li>';
+    }).join('');
+    if (canonicalCategories.indexOf(query) === -1) {
+      html += '<li class="is-new" data-value="' + escHtml(query) + '">' + escHtml(query) + '</li>';
+    }
+    epCategorySuggestions.innerHTML = html;
+    epCategorySuggestions.hidden = html === '';
+  });
+
+  function addPanelCategory(val) {
+    val = val.toUpperCase();
+    var current = getPanelCategories();
+    if (!val || current.indexOf(val) !== -1) return;
+    renderPanelCategoryTags(current.concat([val]));
+    if (canonicalCategories.indexOf(val) === -1) {
+      canonicalCategories.push(val);
+      canonicalCategories.sort();
+    }
+    epCategoryInput.value = '';
+    epCategorySuggestions.hidden = true;
+  }
+
+  epCategorySuggestions.addEventListener('click', function(e) {
+    var li = e.target.closest('li');
+    if (!li) return;
+    addPanelCategory(li.dataset.value);
+  });
+
+  epCategoryInput.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addPanelCategory(this.value.trim());
+    }
+    if (e.key === 'Escape') epCategorySuggestions.hidden = true;
   });
 
   // ---- Related projects editor ----
@@ -959,6 +980,52 @@
     epRelatedProjectInput.value = '';
     epRelatedProjectSuggestions.hidden = true;
   }
+
+  // ---- Markdown preview ----
+  function simpleMarkdown(text) {
+    if (!text) return '';
+    var lines = text.split('\n');
+    var html = '';
+    var inList = false;
+    lines.forEach(function(rawLine) {
+      var line = rawLine
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*(.+?)\*/g, '<em>$1</em>')
+        .replace(/`(.+?)`/g, '<code>$1</code>');
+      if (/^### /.test(line)) {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += '<h3>' + line.slice(4) + '</h3>';
+      } else if (/^## /.test(line)) {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += '<h2>' + line.slice(3) + '</h2>';
+      } else if (/^# /.test(line)) {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += '<h1>' + line.slice(2) + '</h1>';
+      } else if (/^[-*] /.test(line)) {
+        if (!inList) { html += '<ul>'; inList = true; }
+        html += '<li>' + line.slice(2) + '</li>';
+      } else if (line.trim() === '') {
+        if (inList) { html += '</ul>'; inList = false; }
+      } else {
+        if (inList) { html += '</ul>'; inList = false; }
+        html += '<p>' + line + '</p>';
+      }
+    });
+    if (inList) html += '</ul>';
+    return html;
+  }
+
+  var previewMode = false;
+  epPreviewToggle.addEventListener('click', function() {
+    previewMode = !previewMode;
+    epBody.hidden = previewMode;
+    epBodyPreview.hidden = !previewMode;
+    this.textContent = previewMode ? 'Edit' : 'Preview';
+    if (previewMode) epBodyPreview.innerHTML = simpleMarkdown(epBody.value);
+  });
 
   // ---- Manage labels modal (rename categories + types) ----
 

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -9,10 +9,11 @@
   var projectSlugs = (window.__PROJECT_SLUGS__ || []).slice();
   var token = '';
   var changes = {};
-  var sortField = 'title';
-  var sortDir = 'asc';
+  var sortField = 'date';
+  var sortDir = 'desc';
   var searchQuery = '';
   var typeFilter = 'all';
+  var categoryFilter = 'all';
   var draftFilter = 'all'; // 'all', 'draft', 'published'
   var selectedPaths = new Set();
   var activeEditPath = null;
@@ -54,6 +55,7 @@
   var tbody = document.getElementById('entries-tbody');
   var searchInput = document.getElementById('search-input');
   var typeFiltersEl = document.getElementById('type-filters');
+  var categoryFiltersEl = document.getElementById('category-filters');
   var draftFiltersEl = document.getElementById('draft-filters');
   var selectAllCb = document.getElementById('select-all');
   var bulkActions = document.getElementById('bulk-actions');
@@ -133,22 +135,64 @@
     if (!adminInitialized) {
       adminInitialized = true;
       buildTypeFilters();
+      buildCategoryFilters();
+      // Set initial sort indicator
+      var initialSortTh = document.querySelector('th[data-sort="date"]');
+      if (initialSortTh) initialSortTh.classList.add('sort-desc');
       // Track actual toolbar height for sticky table header
       var adminToolbar = document.querySelector('.admin-toolbar');
-      var ro = new ResizeObserver(function(entries) {
-        var h = Math.ceil(entries[0].contentRect.height);
+      function updateToolbarHeight() {
+        var h = Math.ceil(adminToolbar.getBoundingClientRect().height);
         document.documentElement.style.setProperty('--admin-toolbar-actual-height', h + 'px');
-      });
+      }
+      updateToolbarHeight();
+      var ro = new ResizeObserver(updateToolbarHeight);
       ro.observe(adminToolbar);
     }
     renderTable();
   }
 
-  // ---- Draft filter ----
-  draftFiltersEl.addEventListener('change', function(e) {
-    draftFilter = e.target.value;
-    renderTable();
-  });
+  // ---- Draft filter dropdown ----
+  (function() {
+    var btn = draftFiltersEl.querySelector('.admin-dropdown__button');
+    var label = draftFiltersEl.querySelector('.admin-dropdown__label');
+    var drawer = draftFiltersEl.querySelector('.admin-dropdown__drawer');
+    var items = draftFiltersEl.querySelectorAll('.admin-dropdown__item');
+
+    function openDropdown() {
+      draftFiltersEl.classList.add('is-open');
+      btn.setAttribute('aria-expanded', 'true');
+      drawer.setAttribute('aria-hidden', 'false');
+    }
+    function closeDropdown() {
+      draftFiltersEl.classList.remove('is-open');
+      btn.setAttribute('aria-expanded', 'false');
+      drawer.setAttribute('aria-hidden', 'true');
+    }
+
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      draftFiltersEl.classList.contains('is-open') ? closeDropdown() : openDropdown();
+    });
+
+    items.forEach(function(item) {
+      item.addEventListener('click', function() {
+        draftFilter = item.dataset.value;
+        label.textContent = item.dataset.value === 'all' ? 'STATUS' : item.textContent;
+        items.forEach(function(i) { i.classList.remove('is-selected'); });
+        item.classList.add('is-selected');
+        closeDropdown();
+        renderTable();
+      });
+    });
+
+    document.addEventListener('click', function(e) {
+      if (!draftFiltersEl.contains(e.target)) closeDropdown();
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeDropdown();
+    });
+  })();
 
   sessionStorage.removeItem('admin_token');
 
@@ -186,40 +230,163 @@
 
   // ---- Type filters ----
   function buildTypeFilters() {
+    var btn = typeFiltersEl.querySelector('.admin-dropdown__button');
+    var label = typeFiltersEl.querySelector('.admin-dropdown__label');
+    var drawer = typeFiltersEl.querySelector('.admin-dropdown__drawer');
+    var allItem = drawer.querySelector('[data-value="all"]');
+    var selectedTypes = new Set(); // empty = all
+
+    // Populate items from entryTypes
     var frag = document.createDocumentFragment();
     entryTypes.forEach(function(t) {
-      var label = document.createElement('label');
-      label.className = 'filter-chip';
-      var input = document.createElement('input');
-      input.type = 'checkbox';
-      input.value = t.toLowerCase();
-      label.appendChild(input);
-      label.appendChild(document.createTextNode(' ' + t));
-      frag.appendChild(label);
+      var item = document.createElement('button');
+      item.className = 'admin-dropdown__item';
+      item.type = 'button';
+      item.dataset.value = t.toLowerCase();
+      item.textContent = t;
+      frag.appendChild(item);
     });
-    typeFiltersEl.appendChild(frag);
+    drawer.appendChild(frag);
 
-    typeFiltersEl.addEventListener('change', function(e) {
-      var target = e.target;
-      if (target.value === 'all') {
-        if (target.checked) {
-          typeFiltersEl.querySelectorAll('input:not([value="all"])').forEach(function(cb) { cb.checked = false; });
-          typeFilter = 'all';
-        }
+    function updateLabel() {
+      label.textContent = selectedTypes.size === 0 ? 'ALL TYPES' : Array.from(selectedTypes).join(', ').toUpperCase();
+    }
+
+    function openDropdown() {
+      typeFiltersEl.classList.add('is-open');
+      btn.setAttribute('aria-expanded', 'true');
+      drawer.setAttribute('aria-hidden', 'false');
+    }
+    function closeDropdown() {
+      typeFiltersEl.classList.remove('is-open');
+      btn.setAttribute('aria-expanded', 'false');
+      drawer.setAttribute('aria-hidden', 'true');
+    }
+
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      typeFiltersEl.classList.contains('is-open') ? closeDropdown() : openDropdown();
+    });
+
+    drawer.addEventListener('click', function(e) {
+      var item = e.target.closest('.admin-dropdown__item');
+      if (!item) return;
+      var val = item.dataset.value;
+      if (val === 'all') {
+        selectedTypes.clear();
+        drawer.querySelectorAll('.admin-dropdown__item').forEach(function(i) { i.classList.remove('is-selected'); });
+        allItem.classList.add('is-selected');
+        typeFilter = 'all';
       } else {
-        typeFiltersEl.querySelector('input[value="all"]').checked = false;
-        var checked = [];
-        typeFiltersEl.querySelectorAll('input:checked').forEach(function(cb) {
-          if (cb.value !== 'all') checked.push(cb.value);
-        });
-        if (checked.length === 0) {
-          typeFiltersEl.querySelector('input[value="all"]').checked = true;
+        allItem.classList.remove('is-selected');
+        if (selectedTypes.has(val)) {
+          selectedTypes.delete(val);
+          item.classList.remove('is-selected');
+        } else {
+          selectedTypes.add(val);
+          item.classList.add('is-selected');
+        }
+        if (selectedTypes.size === 0) {
+          allItem.classList.add('is-selected');
           typeFilter = 'all';
         } else {
-          typeFilter = checked;
+          typeFilter = Array.from(selectedTypes);
         }
       }
+      updateLabel();
       renderTable();
+    });
+
+    document.addEventListener('click', function(e) {
+      if (!typeFiltersEl.contains(e.target)) closeDropdown();
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeDropdown();
+    });
+  }
+
+  // ---- Category filters ----
+  function buildCategoryFilters() {
+    var btn = categoryFiltersEl.querySelector('.admin-dropdown__button');
+    var label = categoryFiltersEl.querySelector('.admin-dropdown__label');
+    var drawer = categoryFiltersEl.querySelector('.admin-dropdown__drawer');
+    var allItem = drawer.querySelector('[data-value="all"]');
+    var selectedCategories = new Set();
+
+    // Collect all unique categories from entries
+    var allCategories = [];
+    entries.forEach(function(e) {
+      (e.categories || []).forEach(function(c) {
+        if (allCategories.indexOf(c) === -1) allCategories.push(c);
+      });
+    });
+    allCategories.sort();
+
+    var frag = document.createDocumentFragment();
+    allCategories.forEach(function(c) {
+      var item = document.createElement('button');
+      item.className = 'admin-dropdown__item';
+      item.type = 'button';
+      item.dataset.value = c.toLowerCase();
+      item.textContent = c;
+      frag.appendChild(item);
+    });
+    drawer.appendChild(frag);
+
+    function updateLabel() {
+      label.textContent = selectedCategories.size === 0 ? 'ALL CATEGORIES' : Array.from(selectedCategories).join(', ').toUpperCase();
+    }
+
+    function openDropdown() {
+      categoryFiltersEl.classList.add('is-open');
+      btn.setAttribute('aria-expanded', 'true');
+      drawer.setAttribute('aria-hidden', 'false');
+    }
+    function closeDropdown() {
+      categoryFiltersEl.classList.remove('is-open');
+      btn.setAttribute('aria-expanded', 'false');
+      drawer.setAttribute('aria-hidden', 'true');
+    }
+
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      categoryFiltersEl.classList.contains('is-open') ? closeDropdown() : openDropdown();
+    });
+
+    drawer.addEventListener('click', function(e) {
+      var item = e.target.closest('.admin-dropdown__item');
+      if (!item) return;
+      var val = item.dataset.value;
+      if (val === 'all') {
+        selectedCategories.clear();
+        drawer.querySelectorAll('.admin-dropdown__item').forEach(function(i) { i.classList.remove('is-selected'); });
+        allItem.classList.add('is-selected');
+        categoryFilter = 'all';
+      } else {
+        allItem.classList.remove('is-selected');
+        if (selectedCategories.has(val)) {
+          selectedCategories.delete(val);
+          item.classList.remove('is-selected');
+        } else {
+          selectedCategories.add(val);
+          item.classList.add('is-selected');
+        }
+        if (selectedCategories.size === 0) {
+          allItem.classList.add('is-selected');
+          categoryFilter = 'all';
+        } else {
+          categoryFilter = Array.from(selectedCategories);
+        }
+      }
+      updateLabel();
+      renderTable();
+    });
+
+    document.addEventListener('click', function(e) {
+      if (!categoryFiltersEl.contains(e.target)) closeDropdown();
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeDropdown();
     });
   }
 
@@ -353,6 +520,13 @@
     if (typeFilter !== 'all') {
       filtered = filtered.filter(function(e) {
         return typeFilter.indexOf((e.entryType || '').toLowerCase()) !== -1;
+      });
+    }
+
+    if (categoryFilter !== 'all') {
+      filtered = filtered.filter(function(e) {
+        var cats = (e.categories || []).map(function(c) { return c.toLowerCase(); });
+        return categoryFilter.some(function(c) { return cats.indexOf(c) !== -1; });
       });
     }
 

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -61,24 +61,29 @@
   var bulkActions = document.getElementById('bulk-actions');
   var selectedCountEl = document.getElementById('selected-count');
   var saveBtn = document.getElementById('save-btn');
+  var clearBtn = document.getElementById('clear-btn');
+  var clearModal = document.getElementById('clear-modal');
+  var clearModalConfirm = document.getElementById('clear-modal-confirm');
+  var clearModalCancel = document.getElementById('clear-modal-cancel');
   var changeCountEl = document.getElementById('change-count');
   var logoutBtn = document.getElementById('logout-btn');
   var newEntryBtn = document.getElementById('new-entry-btn');
   var bulkModal = document.getElementById('bulk-modal');
-  var bulkModalTitle = document.getElementById('bulk-modal-title');
   var bulkCategoryInput = document.getElementById('bulk-category-input');
   var bulkCategorySuggestions = document.getElementById('bulk-category-suggestions');
   var bulkModalConfirm = document.getElementById('bulk-modal-confirm');
   var bulkModalCancel = document.getElementById('bulk-modal-cancel');
-  var bulkAddBtn = document.getElementById('bulk-add-btn');
-  var bulkRemoveBtn = document.getElementById('bulk-remove-btn');
+  var bulkActionsBtn = document.getElementById('bulk-actions-btn');
+  var bulkTabAdd = document.getElementById('bulk-tab-add');
+  var bulkTabRemove = document.getElementById('bulk-tab-remove');
   var manageBtn = document.getElementById('manage-btn');
   var manageModal = document.getElementById('manage-modal');
   var manageModalClose = document.getElementById('manage-modal-close');
-  var manageCategoriesList = document.getElementById('manage-categories-list');
-  var manageTypesList = document.getElementById('manage-types-list');
+  var manageCategoriesList = document.querySelector('#manage-categories-list tbody');
+  var manageTypesList = document.querySelector('#manage-types-list tbody');
   var manageCategoriesPanel = document.getElementById('manage-categories-panel');
   var manageTypesPanel = document.getElementById('manage-types-panel');
+  var manageCombineBtn = document.getElementById('manage-combine-btn');
   var deleteModal = document.getElementById('delete-modal');
   var deleteModalMsg = document.getElementById('delete-modal-msg');
   var deleteModalConfirm = document.getElementById('delete-modal-confirm');
@@ -246,6 +251,14 @@
       item.textContent = t;
       frag.appendChild(item);
     });
+    if (entries.some(function(e) { return !e.entryType; })) {
+      var noTypeItem = document.createElement('button');
+      noTypeItem.className = 'admin-dropdown__item';
+      noTypeItem.type = 'button';
+      noTypeItem.dataset.value = '';
+      noTypeItem.textContent = 'NO TYPE';
+      frag.appendChild(noTypeItem);
+    }
     drawer.appendChild(frag);
 
     function updateLabel() {
@@ -331,6 +344,14 @@
       item.textContent = c;
       frag.appendChild(item);
     });
+    if (entries.some(function(e) { return !e.categories || e.categories.length === 0; })) {
+      var noCatItem = document.createElement('button');
+      noCatItem.className = 'admin-dropdown__item';
+      noCatItem.type = 'button';
+      noCatItem.dataset.value = '';
+      noCatItem.textContent = 'NO CATEGORY';
+      frag.appendChild(noCatItem);
+    }
     drawer.appendChild(frag);
 
     function updateLabel() {
@@ -465,6 +486,8 @@
   }
 
   // ---- Update changes ----
+  var canonicalCategoriesChanged = false;
+
   function updateChanges() {
     changes = {};
     entries.forEach(function(e) {
@@ -507,10 +530,20 @@
       changes[e.filePath] = change;
     });
 
+    if (canonicalCategoriesChanged) {
+      changes['_data/canonicalCategories.yaml'] = {
+        filePath: '_data/canonicalCategories.yaml',
+        action: 'updateCategories',
+        categories: canonicalCategories.slice()
+      };
+    }
+
     var count = Object.keys(changes).length;
     changeCountEl.hidden = count === 0;
     changeCountEl.textContent = count + ' change' + (count === 1 ? '' : 's');
     saveBtn.disabled = count === 0;
+    clearBtn.disabled = count === 0;
+    clearBtn.hidden = count === 0;
   }
 
   // ---- Render table ----
@@ -526,7 +559,9 @@
     if (categoryFilter !== 'all') {
       filtered = filtered.filter(function(e) {
         var cats = (e.categories || []).map(function(c) { return c.toLowerCase(); });
-        return categoryFilter.some(function(c) { return cats.indexOf(c) !== -1; });
+        return categoryFilter.some(function(c) {
+          return c === '' ? cats.length === 0 : cats.indexOf(c) !== -1;
+        });
       });
     }
 
@@ -577,6 +612,15 @@
       // Title
       html += '<td class="col-title">' + escHtml(entry.title || entry.slug || '') + '</td>';
 
+      // Type (read-only)
+      html += '<td class="col-type">';
+      if (entry.entryType) {
+        html += '<span class="cat-tag">' + escHtml(entry.entryType.toUpperCase()) + '</span>';
+      } else {
+        html += '<span class="cat-tag cat-tag--muted">NO TYPE</span>';
+      }
+      html += '</td>';
+
       // Categories (read-only)
       html += '<td class="col-categories"><div class="category-cell">';
       if ((entry.categories || []).length === 0) {
@@ -587,15 +631,6 @@
         });
       }
       html += '</div></td>';
-
-      // Type (read-only)
-      html += '<td class="col-type">';
-      if (entry.entryType) {
-        html += '<span class="cat-tag">' + escHtml(entry.entryType.toUpperCase()) + '</span>';
-      } else {
-        html += '<span class="cell-empty">&mdash;</span>';
-      }
-      html += '</td>';
 
       // Date
       html += '<td class="col-date">' + escHtml(toDateInputValue(entry.date)) + '</td>';
@@ -625,7 +660,6 @@
 
   function updateSelectionUI() {
     var count = selectedPaths.size;
-    bulkActions.hidden = count === 0;
     selectedCountEl.textContent = count + ' selected';
   }
 
@@ -763,6 +797,7 @@
   // ---- Type editing ----
   // All known types. The server maps project→projects/, everything else→other/.
   var knownTypes = ['project', 'news', 'award', 'feature', 'lecture', 'exhibition', 'staff'];
+  var initialKnownTypes = knownTypes.slice();
 
   // Returns the entries/ subfolder for a given type
   function typeFolder(entryType) {
@@ -1211,6 +1246,7 @@
     if (idx !== -1) canonicalCategories.splice(idx, 1, newName);
     else canonicalCategories.push(newName);
     canonicalCategories.sort();
+    canonicalCategoriesChanged = true;
     // Update every entry that has this category
     entries.forEach(function(e) {
       if (!e.categories) return;
@@ -1219,6 +1255,51 @@
     });
     updateChanges();
     renderTable();
+  }
+
+  function deleteCategory(name) {
+    var idx = canonicalCategories.indexOf(name);
+    if (idx !== -1) canonicalCategories.splice(idx, 1);
+    canonicalCategoriesChanged = true;
+    // Strip category from every entry that has it
+    entries.forEach(function(e) {
+      if (!e.categories) return;
+      var ci = e.categories.indexOf(name);
+      if (ci !== -1) e.categories.splice(ci, 1);
+    });
+    updateChanges();
+    renderTable();
+  }
+
+  function deleteType(name) {
+    if (name === 'project') {
+      alert('The "project" type cannot be deleted.');
+      return;
+    }
+    var idx = knownTypes.indexOf(name);
+    if (idx !== -1) knownTypes.splice(idx, 1);
+    entries.forEach(function(e) {
+      if (e.entryType === name) e.entryType = null;
+    });
+    updateChanges();
+    renderTable();
+    refreshTypeFilterNoTypeItem();
+  }
+
+  function refreshTypeFilterNoTypeItem() {
+    var drawer = typeFiltersEl.querySelector('.admin-dropdown__drawer');
+    var existing = drawer.querySelector('[data-value=""]');
+    var hasNoType = entries.some(function(e) { return !e.entryType; });
+    if (hasNoType && !existing) {
+      var item = document.createElement('button');
+      item.className = 'admin-dropdown__item';
+      item.type = 'button';
+      item.dataset.value = '';
+      item.textContent = 'NO TYPE';
+      drawer.appendChild(item);
+    } else if (!hasNoType && existing) {
+      existing.remove();
+    }
   }
 
   function renameType(oldName, newName) {
@@ -1245,11 +1326,39 @@
     renderTable();
   }
 
-  function renderManageList(ul, items, onRename) {
-    ul.innerHTML = '';
+  function renderManageList(tbody, items, onRename, onDelete, isCategories, onSelectionChange) {
+    tbody.innerHTML = '';
     items.forEach(function(name) {
-      var li = document.createElement('li');
-      li.className = 'manage-list-item';
+      // Count entries using this label
+      var count = 0;
+      if (isCategories) {
+        entries.forEach(function(e) {
+          if (e.categories && e.categories.indexOf(name) !== -1) count++;
+        });
+      } else {
+        entries.forEach(function(e) {
+          if (e.entryType === name) count++;
+        });
+      }
+
+      var tr = document.createElement('tr');
+
+      // Select cell
+      var tdSelect = document.createElement('td');
+      tdSelect.className = 'manage-col-select';
+      var cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.className = 'manage-row-checkbox';
+      cb.dataset.name = name;
+      cb.addEventListener('change', function() {
+        if (onSelectionChange) onSelectionChange();
+      });
+      tdSelect.appendChild(cb);
+      tr.appendChild(tdSelect);
+
+      // Label cell
+      var tdLabel = document.createElement('td');
+      tdLabel.className = 'manage-col-label';
 
       var label = document.createElement('span');
       label.className = 'manage-list-label';
@@ -1261,8 +1370,20 @@
       input.value = name.toUpperCase();
       input.hidden = true;
 
+      tdLabel.appendChild(label);
+      tdLabel.appendChild(input);
+
+      // Count cell
+      var tdCount = document.createElement('td');
+      tdCount.className = 'manage-col-count';
+      tdCount.textContent = count || '';
+
+      // Actions cell
+      var tdActions = document.createElement('td');
+      tdActions.className = 'manage-col-actions';
+
       var editBtn = document.createElement('button');
-      editBtn.className = 'btn btn--small';
+      editBtn.className = 'btn btn--small btn--secondary';
       editBtn.textContent = 'Rename';
 
       editBtn.addEventListener('click', function() {
@@ -1270,6 +1391,7 @@
           // Enter edit mode
           input.value = name.toUpperCase();
           label.hidden = true;
+          if (delBtn) delBtn.hidden = true;
           input.hidden = false;
           editBtn.textContent = 'Save';
           input.focus();
@@ -1279,12 +1401,11 @@
           var newVal = input.value.trim();
           if (newVal && newVal !== name.toUpperCase()) {
             onRename(name, newVal);
-            // Refresh the whole list after rename
-            renderManageList(ul, items.map(function(n) { return n === name ? newVal.toLowerCase() : n; }), onRename);
             return;
           }
           // No change — just cancel
           label.hidden = false;
+          if (delBtn) delBtn.hidden = false;
           input.hidden = true;
           editBtn.textContent = 'Rename';
         }
@@ -1294,27 +1415,115 @@
         if (e.key === 'Enter') editBtn.click();
         if (e.key === 'Escape') {
           label.hidden = false;
+          if (delBtn) delBtn.hidden = false;
           input.hidden = true;
           editBtn.textContent = 'Rename';
         }
       });
 
-      li.appendChild(label);
-      li.appendChild(input);
-      li.appendChild(editBtn);
-      ul.appendChild(li);
+      var delBtn = null;
+      if (onDelete) {
+        delBtn = document.createElement('button');
+        delBtn.className = 'btn btn--small btn--danger';
+        delBtn.textContent = 'Del';
+        delBtn.addEventListener('click', function() {
+          if (count > 0 && !window.confirm('Remove "' + name.toUpperCase() + '" from all ' + count + ' entries?')) return;
+          onDelete(name);
+        });
+      }
+      tdActions.appendChild(editBtn);
+      if (delBtn) tdActions.appendChild(delBtn);
+
+      tr.appendChild(tdLabel);
+      tr.appendChild(tdCount);
+      tr.appendChild(tdActions);
+      tbody.appendChild(tr);
     });
   }
 
+  function getSelectedManageNames(tbody) {
+    var checked = tbody.querySelectorAll('.manage-row-checkbox:checked');
+    return Array.prototype.map.call(checked, function(cb) { return cb.dataset.name; });
+  }
+
+  function updateCombineBtn() {
+    // Determine which panel is active
+    var activeIsCategories = !manageCategoriesPanel.hidden;
+    var tbody = activeIsCategories ? manageCategoriesList : manageTypesList;
+    var selected = getSelectedManageNames(tbody);
+    if (selected.length >= 2) {
+      manageCombineBtn.textContent = 'Combine ' + selected.length + ' Labels';
+      manageCombineBtn.hidden = false;
+    } else {
+      manageCombineBtn.hidden = true;
+    }
+  }
+
   function openManageModal() {
-    renderManageList(manageCategoriesList, canonicalCategories.slice(), function(oldName, newName) {
+    function onCategoryRename(oldName, newName) {
       renameCategory(oldName, newName.toUpperCase());
-      renderManageList(manageCategoriesList, canonicalCategories.slice(), arguments.callee);
-    });
-    renderManageList(manageTypesList, knownTypes.slice(), function(oldName, newName) {
+      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
+      updateCombineBtn();
+    }
+    function onCategoryDelete(name) {
+      deleteCategory(name);
+      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
+      updateCombineBtn();
+    }
+    function onTypeRename(oldName, newName) {
       renameType(oldName, newName.toLowerCase());
-      renderManageList(manageTypesList, knownTypes.slice(), arguments.callee);
-    });
+      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
+      updateCombineBtn();
+    }
+    function onTypeDelete(name) {
+      deleteType(name);
+      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
+      updateCombineBtn();
+    }
+
+    function combineSelected() {
+      var activeIsCategories = !manageCategoriesPanel.hidden;
+      var tbody = activeIsCategories ? manageCategoriesList : manageTypesList;
+      var selected = getSelectedManageNames(tbody);
+      if (selected.length < 2) return;
+      var target = window.prompt('Combine into label (all selected will be renamed to this):', selected[0].toUpperCase());
+      if (!target) return;
+      target = target.trim();
+      if (!target) return;
+      // Apply renames: for each selected name, rename to target
+      selected.forEach(function(name) {
+        if (activeIsCategories) {
+          renameCategory(name, target.toUpperCase());
+        } else {
+          renameType(name, target.toLowerCase());
+        }
+      });
+      // Deduplicate in case the target already existed before combining
+      if (activeIsCategories) {
+        var seen = {};
+        canonicalCategories = canonicalCategories.filter(function(c) {
+          if (seen[c]) return false;
+          seen[c] = true;
+          return true;
+        });
+        renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
+      } else {
+        var seenT = {};
+        knownTypes = knownTypes.filter(function(t) {
+          if (seenT[t]) return false;
+          seenT[t] = true;
+          return true;
+        });
+        renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
+      }
+      updateCombineBtn();
+    }
+
+    manageCombineBtn.onclick = combineSelected;
+
+    renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
+    renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
+    manageCombineBtn.hidden = true;
     manageModal.hidden = false;
   }
 
@@ -1330,29 +1539,48 @@
     });
     manageCategoriesPanel.hidden = tab !== 'categories';
     manageTypesPanel.hidden = tab !== 'types';
+    updateCombineBtn();
   });
 
   // ---- Bulk operations ----
   var bulkMode = null;
 
-  bulkAddBtn.addEventListener('click', function() {
-    bulkMode = 'add';
-    bulkModalTitle.textContent = 'Add Category to Selected';
+  function openBulkModal(mode) {
+    bulkMode = mode;
+    bulkTabAdd.classList.toggle('is-active', mode === 'add');
+    bulkTabRemove.classList.toggle('is-active', mode === 'remove');
+    var tbody = document.getElementById('bulk-entries-body');
+    tbody.innerHTML = '';
+    entries.forEach(function(e) {
+      if (!selectedPaths.has(e.filePath)) return;
+      var tr = document.createElement('tr');
+      var tdTitle = document.createElement('td');
+      tdTitle.className = 'bulk-col-title manage-list-label';
+      tdTitle.textContent = e.title || e.slug;
+      var tdCats = document.createElement('td');
+      tdCats.className = 'bulk-col-categories manage-list-label';
+      tdCats.textContent = (e.categories || []).join(', ');
+      tr.appendChild(tdTitle);
+      tr.appendChild(tdCats);
+      tbody.appendChild(tr);
+    });
     bulkCategoryInput.value = '';
     bulkCategorySuggestions.innerHTML = '';
     bulkModal.hidden = false;
     bulkCategoryInput.focus();
     renderBulkSuggestions('');
+  }
+
+  bulkActionsBtn.addEventListener('click', function() {
+    openBulkModal('add');
   });
 
-  bulkRemoveBtn.addEventListener('click', function() {
-    bulkMode = 'remove';
-    bulkModalTitle.textContent = 'Remove Category from Selected';
-    bulkCategoryInput.value = '';
-    bulkCategorySuggestions.innerHTML = '';
-    bulkModal.hidden = false;
-    bulkCategoryInput.focus();
-    renderBulkSuggestions('');
+  bulkTabAdd.addEventListener('click', function() {
+    openBulkModal('add');
+  });
+
+  bulkTabRemove.addEventListener('click', function() {
+    openBulkModal('remove');
   });
 
   bulkModalCancel.addEventListener('click', function() { bulkModal.hidden = true; });
@@ -1364,8 +1592,6 @@
   bulkCategoryInput.addEventListener('keydown', function(e) {
     if (e.key === 'Enter') {
       e.preventDefault();
-      var val = this.value.trim().toUpperCase();
-      if (val) applyBulk(val);
     }
     if (e.key === 'Escape') bulkModal.hidden = true;
   });
@@ -1399,7 +1625,8 @@
   bulkCategorySuggestions.addEventListener('click', function(e) {
     var li = e.target.closest('li');
     if (!li) return;
-    applyBulk(li.dataset.value);
+    bulkCategoryInput.value = li.dataset.value;
+    bulkCategorySuggestions.innerHTML = '';
   });
 
   bulkModalConfirm.addEventListener('click', function() {
@@ -1425,6 +1652,48 @@
     updateChanges();
     renderTable();
   }
+
+  // ---- Clear changes ----
+  clearBtn.addEventListener('click', function() {
+    clearModal.hidden = false;
+  });
+  clearModalCancel.addEventListener('click', function() {
+    clearModal.hidden = true;
+  });
+  clearModalConfirm.addEventListener('click', function() {
+    clearModal.hidden = true;
+    // Revert entries to originals, remove new/deleted entries
+    entries = entries.filter(function(e) { return !e._isNew; });
+    entries.forEach(function(e) {
+      delete e._delete;
+      var orig = originals[e.filePath];
+      if (!orig) return;
+      e.categories = orig.categories.slice();
+      e.entryType = orig.entryType;
+      e.draft = orig.draft;
+      e.title = orig.title;
+      e.subtitle = orig.subtitle;
+      e.description = orig.description;
+      e.date = orig.date;
+      e.link = orig.link;
+      e.position = orig.position;
+      e.year = orig.year;
+      e.location = orig.location;
+      e.status = orig.status;
+      e.featured = orig.featured;
+      e.featuredPosition = orig.featuredPosition;
+      e.collaborators = JSON.parse(orig.collaborators);
+      e.relatedProjects = JSON.parse(orig.relatedProjects);
+      e.body = orig.body;
+    });
+    canonicalCategories = (window.__CATEGORIES__ || []).slice();
+    canonicalCategoriesChanged = false;
+    knownTypes = initialKnownTypes.slice();
+    changes = {};
+    closeEditPanel();
+    updateChanges();
+    renderTable();
+  });
 
   // ---- Save ----
   saveBtn.addEventListener('click', function() {
@@ -1473,6 +1742,7 @@
         originals[e.filePath] = snapshot(e);
       });
 
+      canonicalCategoriesChanged = false;
       changes = {};
       updateChanges();
 

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -17,17 +17,53 @@ eleventyExcludeFromCollections: true
 </head>
 <body>
 
-  {# Login screen #}
+  {# Login screen — 4 columns × 5 rows grid #}
+  {# Cols: empty | logo | form | empty #}
+  {# Rows: spacer | heading | password | button | spacer #}
   <div id="login-screen" class="login-screen">
-    <div class="login-box">
+
+    {# Explicitly placed content cells #}
+    <div class="login-cell login-cell--logo">
+      <img src="/assets/uploads/favicon.png" alt="LowDO">
+    </div>
+    <div class="login-cell login-cell--heading">
       <h1>LowDO Admin</h1>
-      <p>Enter password to manage entries.</p>
+    </div>
+    <div class="login-cell login-cell--password">
       <form id="login-form">
-        <input type="password" id="login-password" placeholder="Password" autocomplete="current-password" required>
-        <button type="submit">Log In</button>
+        <input type="password" id="login-password" placeholder="Enter Password" autocomplete="current-password" required>
         <p id="login-error" class="error" hidden></p>
       </form>
     </div>
+    <div class="login-cell login-cell--button">
+      <button type="submit" form="login-form">Login</button>
+    </div>
+
+    {# Auto-placed filler cells to complete the grid (4×5 = 20, minus 4 explicitly-placed cells = 16) #}
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+    <div class="login-cell"></div>
+
+    {# Lines painted last so they render above cell backgrounds #}
+    <div class="login-col-line"></div>
+    <div class="login-row-line login-row-line--top"></div>
+    <div class="login-row-line login-row-line--bottom"></div>
+    <div class="login-row-line login-row-line--heading"></div>
+    <div class="login-row-line login-row-line--password"></div>
+
   </div>
 
   {# Admin screen #}
@@ -46,26 +82,45 @@ eleventyExcludeFromCollections: true
 
     {# Toolbar #}
     <div class="admin-toolbar">
+      <div class="admin-toolbar__draft-filters admin-dropdown" id="draft-filters" data-value="all">
+        <button class="admin-dropdown__button" aria-expanded="false" type="button">
+          <span class="admin-dropdown__label">STATUS</span>
+          <svg class="admin-dropdown__chevron" width="8" height="5" viewBox="0 0 8 5" fill="none" aria-hidden="true">
+            <path d="M1 1l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+          </svg>
+        </button>
+        <div class="admin-dropdown__drawer" aria-hidden="true">
+          <button class="admin-dropdown__item is-selected" type="button" data-value="all">ALL</button>
+          <button class="admin-dropdown__item" type="button" data-value="draft">DRAFT</button>
+          <button class="admin-dropdown__item" type="button" data-value="published">PUBLISHED</button>
+        </div>
+      </div>
       <div class="admin-toolbar__search">
         <input type="text" id="search-input" placeholder="Search by title or slug...">
       </div>
-      <div class="admin-toolbar__filters" id="type-filters">
-        <label class="filter-chip">
-          <input type="checkbox" value="all" checked> ALL
-        </label>
-      </div>
-      <div class="admin-toolbar__draft-filters" id="draft-filters">
-        <label class="filter-chip">
-          <input type="radio" name="draft-filter" value="all" checked> ALL
-        </label>
-        <label class="filter-chip">
-          <input type="radio" name="draft-filter" value="draft"> DRAFT
-        </label>
-        <label class="filter-chip">
-          <input type="radio" name="draft-filter" value="published"> PUBLISHED
-        </label>
-      </div>
-      <div class="admin-toolbar__manage">
+      <div class="admin-toolbar__categories">
+        <div class="admin-dropdown admin-dropdown--multi" id="type-filters">
+          <button class="admin-dropdown__button" aria-expanded="false" type="button">
+            <span class="admin-dropdown__label">ALL TYPES</span>
+            <svg class="admin-dropdown__chevron" width="8" height="5" viewBox="0 0 8 5" fill="none" aria-hidden="true">
+              <path d="M1 1l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+            </svg>
+          </button>
+          <div class="admin-dropdown__drawer" aria-hidden="true">
+            <button class="admin-dropdown__item is-selected" type="button" data-value="all">ALL</button>
+          </div>
+        </div>
+        <div class="admin-dropdown admin-dropdown--multi" id="category-filters">
+          <button class="admin-dropdown__button" aria-expanded="false" type="button">
+            <span class="admin-dropdown__label">ALL CATEGORIES</span>
+            <svg class="admin-dropdown__chevron" width="8" height="5" viewBox="0 0 8 5" fill="none" aria-hidden="true">
+              <path d="M1 1l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+            </svg>
+          </button>
+          <div class="admin-dropdown__drawer" aria-hidden="true">
+            <button class="admin-dropdown__item is-selected" type="button" data-value="all">ALL</button>
+          </div>
+        </div>
         <button id="manage-btn" class="btn btn--small">Manage Labels</button>
       </div>
       <div class="admin-toolbar__bulk" id="bulk-actions" hidden>

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -9,6 +9,8 @@ eleventyExcludeFromCollections: true
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LowDO Admin</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Overpass+Mono:wght@300..700&display=swap">
   <style>
     {% include "assets/css/admin.css" %}
   </style>

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -52,6 +52,17 @@ eleventyExcludeFromCollections: true
           <input type="checkbox" value="all" checked> ALL
         </label>
       </div>
+      <div class="admin-toolbar__draft-filters" id="draft-filters">
+        <label class="filter-chip">
+          <input type="radio" name="draft-filter" value="all" checked> ALL
+        </label>
+        <label class="filter-chip">
+          <input type="radio" name="draft-filter" value="draft"> DRAFT
+        </label>
+        <label class="filter-chip">
+          <input type="radio" name="draft-filter" value="published"> PUBLISHED
+        </label>
+      </div>
       <div class="admin-toolbar__manage">
         <button id="manage-btn" class="btn btn--small">Manage Labels</button>
       </div>
@@ -69,7 +80,6 @@ eleventyExcludeFromCollections: true
           <tr>
             <th class="col-select"><input type="checkbox" id="select-all"></th>
             <th class="col-draft">Draft</th>
-            <th class="col-slug sortable" data-sort="slug">Slug</th>
             <th class="col-title sortable" data-sort="title">Title</th>
             <th class="col-categories">Categories</th>
             <th class="col-type sortable" data-sort="entryType">Type</th>
@@ -89,82 +99,122 @@ eleventyExcludeFromCollections: true
       </div>
       <div class="edit-panel__body">
 
-        <div class="field-group">
-          <label>Title</label>
-          <input type="text" id="ep-title">
+        {# Section: Identity #}
+        <div class="ep-section">
+          <div class="ep-section__label">Identity</div>
+          <div class="field-group">
+            <label>Slug</label>
+            <input type="text" id="ep-slug" readonly>
+          </div>
+          <div class="field-group">
+            <label>Type</label>
+            <div class="ep-type-display">
+              <span id="ep-type-value" class="cat-tag type-tag"></span>
+              <button id="ep-type-change" class="btn btn--small">Change</button>
+            </div>
+          </div>
+          <div class="field-group">
+            <label class="field-label--inline">
+              <input type="checkbox" id="ep-draft"> Draft
+            </label>
+          </div>
         </div>
 
-        <div class="field-group">
-          <label>Subtitle</label>
-          <input type="text" id="ep-subtitle">
+        {# Section: Content #}
+        <div class="ep-section">
+          <div class="ep-section__label">Content</div>
+          <div class="field-group">
+            <label>Title</label>
+            <input type="text" id="ep-title">
+          </div>
+          <div class="field-group">
+            <label>Subtitle</label>
+            <input type="text" id="ep-subtitle">
+          </div>
+          <div class="field-group">
+            <label>Description</label>
+            <textarea id="ep-description" rows="2"></textarea>
+          </div>
+          <div class="field-group">
+            <label>Date</label>
+            <input type="date" id="ep-date">
+          </div>
         </div>
 
-        <div class="field-group">
-          <label>Description</label>
-          <textarea id="ep-description" rows="2"></textarea>
+        {# Section: Metadata #}
+        <div class="ep-section">
+          <div class="ep-section__label">Metadata</div>
+          <div class="field-group">
+            <label>Categories</label>
+            <div id="ep-categories-tags" class="tag-list"></div>
+            <div class="tag-input-wrap">
+              <input type="text" id="ep-category-input" placeholder="Add category..." autocomplete="off">
+              <ul id="ep-category-suggestions" class="tag-suggestions" hidden></ul>
+            </div>
+          </div>
+          <div class="field-group">
+            <label>Link (external URL)</label>
+            <input type="url" id="ep-link" placeholder="https://...">
+          </div>
+          <div class="field-group">
+            <label>Position (sort order)</label>
+            <input type="number" id="ep-position" placeholder="999">
+          </div>
+          <div class="field-group project-only">
+            <label>Year</label>
+            <input type="text" id="ep-year" placeholder="2024 or 2020 - Present">
+          </div>
+          <div class="field-group project-only">
+            <label>Location</label>
+            <input type="text" id="ep-location">
+          </div>
+          <div class="field-group project-only">
+            <label>Status</label>
+            <input type="text" id="ep-status" placeholder="Built / In Progress / Unbuilt">
+          </div>
         </div>
 
-        <div class="field-group">
-          <label>Date</label>
-          <input type="date" id="ep-date">
+        {# Section: Homepage (project-only) #}
+        <div class="ep-section project-only">
+          <div class="ep-section__label">Homepage</div>
+          <div class="field-group">
+            <label class="field-label--inline">
+              <input type="checkbox" id="ep-featured"> Featured on homepage
+            </label>
+          </div>
+          <div class="field-group" id="ep-featured-position-group" hidden>
+            <label>Featured Position</label>
+            <input type="number" id="ep-featured-position" min="1" placeholder="1">
+          </div>
         </div>
 
-        <div class="field-group">
-          <label>Link (external URL)</label>
-          <input type="url" id="ep-link" placeholder="https://...">
+        {# Section: Body #}
+        <div class="ep-section">
+          <div class="ep-section__label ep-section__label--row">
+            Body (Markdown)
+            <button id="ep-preview-toggle" class="btn btn--small">Preview</button>
+          </div>
+          <div class="field-group">
+            <textarea id="ep-body" rows="10" placeholder="Write markdown here..."></textarea>
+          </div>
+          <div id="ep-body-preview" class="ep-body-preview" hidden></div>
         </div>
 
-        <div class="field-group">
-          <label>Position (sort order)</label>
-          <input type="number" id="ep-position" placeholder="999">
-        </div>
-
-        {# Project-only fields #}
-        <div class="field-group project-only">
-          <label>Year</label>
-          <input type="text" id="ep-year" placeholder="2024 or 2020 - Present">
-        </div>
-
-        <div class="field-group project-only">
-          <label>Location</label>
-          <input type="text" id="ep-location">
-        </div>
-
-        <div class="field-group project-only">
-          <label>Status</label>
-          <input type="text" id="ep-status" placeholder="Built / In Progress / Unbuilt">
-        </div>
-
-        <div class="field-group project-only">
-          <label class="field-label--inline">
-            <input type="checkbox" id="ep-featured"> Featured on homepage
-          </label>
-        </div>
-
-        <div class="field-group project-only" id="ep-featured-position-group" hidden>
-          <label>Featured Position</label>
-          <input type="number" id="ep-featured-position" min="1" placeholder="1">
-        </div>
-
-        <div class="field-group project-only">
-          <label>Collaborators</label>
+        {# Section: Collaborators (project-only) #}
+        <div class="ep-section project-only">
+          <div class="ep-section__label">Collaborators</div>
           <div id="ep-collaborators-list" class="structured-list"></div>
           <button id="ep-add-collaborator" class="btn btn--small">+ Add Collaborator</button>
         </div>
 
-        {# Non-project fields #}
-        <div class="field-group non-project-only">
-          <label>Related Projects</label>
+        {# Section: Related Projects (non-project-only) #}
+        <div class="ep-section non-project-only">
+          <div class="ep-section__label">Related Projects</div>
           <div id="ep-related-projects-list" class="tag-list"></div>
           <div class="tag-input-wrap">
             <input type="text" id="ep-related-project-input" placeholder="Type project slug...">
             <ul id="ep-related-project-suggestions" class="tag-suggestions" hidden></ul>
           </div>
-        </div>
-
-        <div class="field-group">
-          <label>Body Text (Markdown)</label>
-          <textarea id="ep-body" rows="10" placeholder="Write markdown here..."></textarea>
         </div>
 
       </div>
@@ -174,12 +224,6 @@ eleventyExcludeFromCollections: true
       </div>
     </div>
     <div id="edit-panel-backdrop" class="edit-panel-backdrop" hidden></div>
-
-    {# Category autocomplete dropdown #}
-    <div id="category-dropdown" class="category-dropdown" hidden>
-      <input type="text" id="category-search" placeholder="Type to search or create...">
-      <ul id="category-list"></ul>
-    </div>
 
     {# Bulk category modal #}
     <div id="bulk-modal" class="modal" hidden>


### PR DESCRIPTION
## Summary

- **Fix sticky header bug** — `<th>` elements now use a `ResizeObserver` to track the toolbar's actual rendered height via a CSS custom property, replacing the hardcoded `top: 85px` that was causing headers to drift outside their `<tr>`
- **Add draft filter** — DRAFT / PUBLISHED / ALL radio chips added to toolbar; the filter logic already existed in JS but had no UI
- **Simplify table** — removed slug column (redundant), categories and type are now read-only displays; the only interactive element left in the table is the draft toggle
- **Restructure edit panel** — flat 16-field list replaced with named sections: Identity (slug, type, draft), Content (title, subtitle, description, date), Metadata (categories, link, position, year, location, status), Homepage (featured), Body (markdown + preview), Collaborators, Related Projects
- **Categories move to panel** — eliminates the dual editing path where categories could be added/removed both inline in the table and in the panel
- **Markdown preview** — toggle button on the Body section renders a live preview of the markdown

## Test plan

- [ ] Log in and scroll the table — `<th>` headers stick correctly below toolbar
- [ ] Toggle DRAFT/PUBLISHED filter chips — table updates correctly
- [ ] Open edit panel — all sections appear with correct fields, project-only sections hidden for non-project entries
- [ ] Add/remove a category in the panel, click Apply — table row updates
- [ ] Change type via panel Change button — project-only sections show/hide, folder routing updates for new entries
- [ ] Toggle markdown preview on body field
- [ ] Create a new entry — slug is editable, edit panel opens immediately
- [ ] Save changes — API call succeeds, change counter clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)