### PR TITLE
Update docs to reflect admin panel as primary editing workflow

### DIFF
--- a/docs/02-adding-content/adding-a-project.md
+++ b/docs/02-adding-content/adding-a-project.md
@@ -1,434 +1,94 @@
 # How to Add a Project
 
-Step-by-step guide for adding a design project to the site.
+Projects get their own detail pages with image galleries and appear in the comprehensive index at `/all/`.
 
 ---
 
-## Editing Options
+## Step 1: Open the Admin Panel
 
-You can add a project in two ways:
-
-### Option 1: GitHub Web Editor (No Installation)
-
-Use GitHub.com to create files directly in your browser:
-- ✅ No software to install
-- ✅ Works on any device
-- ✅ Can use AI assistants for help
-- ✅ See [GitHub Web Editor Guide](../05-tools-and-workflow/github-web-editor.md)
-
-**This guide shows the web editor workflow first, then local editing.**
-
-### Option 2: Local Development (Advanced)
-
-Install VS Code and edit files on your computer:
-- ⚡ Faster feedback
-- ⚡ Local preview
-- ⚡ Better for complex changes
-- ⚡ See [Code Editor Setup](../05-tools-and-workflow/code-editor-setup.md)
+Go to `/admin/` and log in. Click **+ New Entry** in the top-right corner. A new blank row appears in the table.
 
 ---
 
-## What You'll Create
+## Step 2: Fill In the Details
 
-When you add a project, you'll create:
-- A folder for your project
-- A text file (`.md`) with project details and metadata
-- Images for the project thumbnail and gallery
+Click **Edit** on the new row to open the side panel. Fill in:
 
----
+| Field | Required | Notes |
+|-------|----------|-------|
+| Title | ✅ | Main project name |
+| Type | ✅ | Set to **project** |
+| Date | ✅ | Project completion date |
+| Subtitle | — | Brief tagline shown below the title |
+| Year | — | Display year instead of full date |
+| Description | — | Short summary shown in the index |
+| Categories | — | Topic tags — use existing ones when possible |
+| Collaborators | — | Name + role pairs for project partners |
+| Status | — | Built / In Progress / Proposed |
+| Location | — | Geographic location |
+| Body Text | — | Full project description (supports markdown) |
 
-## Web Editor Workflow
-
-### Step 1: Go to GitHub.com
-
-1. Navigate to https://github.com/lowdo-bay/lowdo-dot-net
-2. Navigate to `entries/projects/` folder
-3. You should see other project folders listed
-
-### Step 2: Create the Project File
-
-1. Click **"Add file"** → **"Create new file"**
-2. In the name field, type the full path:
-   ```
-   your-project-name/your-project-name.md
-   ```
-3. GitHub automatically creates the folder structure
-
-**Naming Rules:**
-- Use lowercase letters only
-- Use hyphens (`-`) instead of spaces
-- Be descriptive but concise
-- This name will appear in the URL
-
-✅ **Good names:**
-- `casa-marianella/casa-marianella.md`
-- `wolf-creek-ranch/wolf-creek-ranch.md`
-- `community-housing-center/community-housing-center.md`
-
-❌ **Bad names:**
-- `Casa Marianella/Casa Marianella.md` (has capitals and spaces)
-- `project1/project1.md` (not descriptive)
-- `new_project/new_project.md` (uses underscores)
-
-### Step 3: Add Project Information
-
-Copy this template and fill in your details:
-
-```yaml
----
-draft: false
-title: "Casa Marianella"
-subtitle: "Community Housing and Resource Center"
-date: 2023-06-15
-year: 2023
-categories:
-  - HOUSING
-  - COMMUNITY
-  - SUSTAINABLE
-collaborators:
-  - name: "Structural Innovations"
-    role: "Structural Engineer"
-  - name: "GreenBuild Contractors"
-    role: "General Contractor"
-description: "A community resource center providing housing and support services"
----
-
-Write your project description here. This text appears on the project detail page.
-
-You can write multiple paragraphs. Use simple formatting like **bold** and *italic*.
-
-## Project Details
-
-You can add sections with headings using ##. Describe the project goals, process, and outcomes in a way that's accessible to visitors.
-
-## Design Approach
-
-Add as many sections as you need to tell the project story.
-```
-
-**The section between `---` lines is called "frontmatter"** - it contains metadata about your project.
-
-See [Frontmatter Reference](frontmatter-reference.md) for details on all available fields.
-
-**Awards & Recognition:** Projects automatically display awards, features, press coverage, and other recognitions that are linked to them. To link an award or news item to this project, see [Adding News & Awards](adding-news-awards.md) and use the `relatedProject` field.
-
-### Image File Naming Conventions
-
-When you add images to your project, use these naming conventions:
-
-| Prefix | Example | Purpose |
-|--------|---------|---------|
-| `header.jpg` | `header.jpg` | Main thumbnail shown in index + top of project page |
-| `00_`, `01_`, etc. | `00_Exterior view.jpg` | Gallery photos (numbered for sort order) |
-| `drawing-` | `drawing-plan_1.jpg` | Floor plans and architectural drawings |
-| `toolkit-` | `toolkit-framing-plan.dwg` | Reference files (CAD, PDF, DWG, etc.) |
-
-**Numbering tip:** Use zero-padded numbers to control order:
-- `00_name.jpg` ← Appears first
-- `01_name.jpg` ← Appears second
-- `02_name.jpg` ← Appears third
-
-### Step 4: Commit the File
-
-1. Scroll down to "Commit changes"
-2. Write a commit message: `Add [Project Name] project`
-3. Select **"Create a new branch for this commit and start a pull request"**
-4. Click "Propose changes"
-5. Click "Create pull request"
-
-### Step 5: Upload Images
-
-1. In your pull request, click on "Files changed" tab, then "Review changes" → "View"
-2. Navigate to your project folder: `entries/projects/your-project-name/`
-3. Click **"Add file"** → **"Upload files"**
-4. Drag and drop your images (or click "choose your files")
-
-**Before uploading, rename your images:**
-- Main thumbnail: `header.jpg` or `thumb.jpg`
-- Gallery images: `01-exterior-view.jpg`, `02-interior-space.jpg`, etc.
-
-5. Make sure to **commit to the same branch** you created earlier
-6. Write commit message: `Add images for [Project Name]`
-7. Click "Commit changes"
-
-### Step 6: Wait for Preview
-
-1. Go back to your pull request
-2. Wait 3-5 minutes for Netlify to build a preview
-3. Look for "netlify/deploy-preview" check
-4. Click "Details" to see your preview site
-
-### Step 7: Test and Merge
-
-1. Navigate to your project on the preview site:
-   - Go to `/all/` to see it in the index
-   - Click it to see the detail page
-2. Check that everything looks correct
-3. If you need to fix something, make more commits to the same branch
-4. When ready, click **"Merge pull request"**
-5. Click **"Confirm merge"**
-
-**Your project goes live in 3-5 minutes!**
+Click **Apply Changes** when done.
 
 ---
 
-## Local Development Workflow
+## Step 3: Save
 
-### Step 1: Navigate to the Projects Folder
+Click **Save Changes** (top right). All pending changes are committed to GitHub in a single operation. The site rebuilds automatically in 3–5 minutes.
 
-Open the `entries/projects/` folder in your text editor or file browser.
-
-This is where **ALL** projects live.
+After saving, the project appears at `/project/{slug}/` and in the index at `/all/`.
 
 ---
 
-## Local Development Workflow (Continued)
+## Step 4: Add Images
 
-### Step 2: Create a New Folder for Your Project
+Images are added directly to the GitHub repository in the project's folder. You can do this through the GitHub web interface:
 
-Create a new folder with a name that describes your project.
+1. Go to [github.com/lowdo-bay/lowdo-dot-net](https://github.com/lowdo-bay/lowdo-dot-net)
+2. Navigate to `entries/projects/{your-project-slug}/`
+3. Click **Add file → Upload files**
+4. Upload your images and commit
 
-**Naming Rules:**
-- Use lowercase letters only
-- Use hyphens (`-`) instead of spaces
-- Be descriptive but concise
-- This name will appear in the URL
+**Naming conventions:**
 
-✅ **Good names:**
-- `casa-marianella`
-- `wolf-creek-ranch`
-- `community-housing-center`
+| Name | Purpose |
+|------|---------|
+| `header.jpg` or `thumb.jpg` | Main thumbnail shown in index and top of project page |
+| `00_description.jpg`, `01_description.jpg`, … | Gallery images (numbered for sort order) |
+| `drawing-plan.jpg` | Floor plans and architectural drawings |
 
-❌ **Bad names:**
-- `Casa Marianella` (has capitals and spaces)
-- `project1` (not descriptive)
-- `new_project` (uses underscores instead of hyphens)
-
-**Example:**
-```
-entries/projects/casa-marianella/
-```
-
-The URL will be: `/project/casa-marianella/`
-
----
-
-### Step 3: Create a Markdown File
-
-Inside your new folder, create a text file with the **same name** as the folder, plus `.md` extension.
-
-**Important:** The folder name and file name must match!
-
-✅ **Correct:**
-```
-casa-marianella/
-└── casa-marianella.md
-```
-
-❌ **Wrong:**
-```
-casa-marianella/
-└── project.md        (doesn't match folder name)
-```
-
----
-
-### Step 4: Add Project Information
-
-Open the `.md` file and add your project information.
-
-Copy this template and fill in your details:
-
-```yaml
----
-draft: false
-title: "Casa Marianella"
-subtitle: "Community Housing and Resource Center"
-date: 2023-06-15
-year: 2023
-categories:
-  - HOUSING
-  - COMMUNITY
-  - SUSTAINABLE
-collaborators:
-  - name: "Structural Innovations"
-    role: "Structural Engineer"
-  - name: "GreenBuild Contractors"
-    role: "General Contractor"
-description: "A community resource center providing housing and support services"
----
-
-Write your project description here. This text appears on the project detail page.
-
-You can write multiple paragraphs. Use simple formatting like **bold** and *italic*.
-
-## Project Details
-
-You can add sections with headings using ##. Describe the project goals, process, and outcomes in a way that's accessible to visitors.
-
-## Design Approach
-
-Add as many sections as you need to tell the project story.
-```
-
-**The section between `---` lines is called "frontmatter"** - it contains metadata about your project.
-
-See [Frontmatter Reference](frontmatter-reference.md) for details on all available fields.
-
-**Awards & Recognition:** Projects automatically display awards, features, press coverage, and other recognitions that are linked to them. To link an award or news item to this project, see [Adding News & Awards](adding-news-awards.md) and use the `relatedProject` field.
-
----
-
-### Step 5: Add Images
-
-Drop image files (`.jpg` or `.png`) into your project folder.
-
-**Thumbnail Image:**
-- Name one image `header.jpg` or `thumb.jpg`
-- This becomes the main thumbnail in the comprehensive index
-
-**Gallery Images:**
-- All other images in the folder are automatically added to the project gallery
-- Name them descriptively: `01-exterior-view.jpg`, `02-interior-space.jpg`, etc.
-- The system displays them in alphabetical order
-
-**Example folder with images:**
-```
-entries/projects/casa-marianella/
-├── casa-marianella.md
-├── header.jpg              ← Thumbnail for index
-├── 01-exterior-view.jpg    ← Gallery image 1
-├── 02-interior-space.jpg   ← Gallery image 2
-└── 03-detail-shot.jpg      ← Gallery image 3
-```
-
-See [Image Guide](image-guide.md) for best practices.
-
----
-
-### Step 6: Save Everything
-
-- Save the `.md` file
-- Make sure all images are in the project folder
-- Your folder structure should look complete
-
----
-
-### Step 7: Commit and Publish (Local)
-
-Save your changes and publish them to the live site using git.
-
-See [Making Commits](../05-tools-and-workflow/making-commits.md) for detailed instructions.
-
-**Quick version:**
-```bash
-git add .
-git commit -m "Add Casa Marianella project"
-git push
-```
-
-Then create a pull request on GitHub.com, wait for preview, test, and merge.
-
----
-
-## What Happens Next?
-
-Once you push your changes to GitHub:
-
-1. **Netlify detects the change** (takes a few seconds)
-2. **The site rebuilds** (takes 3-5 minutes)
-3. **Your project goes live** at `/project/{your-project-name}/`
-4. **The project appears in the comprehensive index** at `/all/`
-5. **Visitors can filter by your categories**
-
----
-
-## Required Fields
-
-These fields **must** be in your frontmatter:
-
-| Field | What It Does | Example |
-|-------|-------------|---------|
-| `draft: false` | Controls visibility (`false` = published) | `draft: false` |
-| `title: "..."` | Project name (shows everywhere) | `title: "Casa Marianella"` |
-| `date: YYYY-MM-DD` | Project completion date | `date: 2023-06-15` |
-
----
-
-## Optional Fields
-
-Add these to enhance your project:
-
-| Field | What It Does | Example |
-|-------|-------------|---------|
-| `subtitle: "..."` | Tagline shown below title | `subtitle: "Community Housing Center"` |
-| `year: YYYY` | Show year instead of full date | `year: 2023` |
-| `categories: [...]` | Topic tags (all caps) | `categories:`<br>`  - HOUSING`<br>`  - DESIGN` |
-| `collaborators: [...]` | Project partners | See template above |
-| `description: "..."` | Short summary | `description: "A housing center..."` |
-| `position: number` | Sort order (lower = first) | `position: 1` |
+See [Image Guide](image-guide.md) for sizes and formats.
 
 ---
 
 ## Tips
 
-**Folder naming:**
-- Keep it short and descriptive
-- The folder name becomes the URL slug
-- You can't easily change it later without breaking links
+**Categories** — Use existing categories when possible to keep filters organized. See [Category Guidelines](../07-reference/category-guidelines.md).
 
-**Title vs. Subtitle:**
-- **Title** = Main project name
-- **Subtitle** = Brief tagline or context
+**Slug** — The slug is auto-generated from the title and date (e.g. `260410_casa-marianella`). It becomes the URL and the folder name on GitHub. You can't easily change it later without breaking links.
 
-**Categories:**
-- Use existing categories when possible (keeps the filters organized)
-- See [Category Guidelines](../07-reference/category-guidelines.md)
-- Format: ALL CAPS, no punctuation
+**Related awards and press** — To show an award or feature on a project's page, link it from the award/news entry using the `relatedProjects` field. See [Adding News & Awards](adding-news-awards.md).
 
-**Images:**
-- One `header.jpg` or `thumb.jpg` is recommended
-- Additional images are optional but make the project page richer
-- See [Image Guide](image-guide.md) for sizes and formats
-
-**Writing content:**
-- Write in markdown (simple text formatting)
-- Use `##` for section headings
-- Use `**bold**` and `*italic*` for emphasis
-- Keep paragraphs short for readability
+**Draft** — New entries default to published. Toggle the draft dot in the table row to hide an entry while you work on it.
 
 ---
 
 ## Troubleshooting
 
 **"My project doesn't appear in the index"**
-- Check `draft: false` (not `draft: true`)
-- Check file naming (folder and `.md` file must match)
-- Check date format (YYYY-MM-DD)
-- Wait 3-5 minutes for the build to complete
+- Check that the draft toggle is grey (published), not red (draft)
+- Wait 3–5 minutes for the site to rebuild after saving
 
-**"The wrong image shows up"**
-- Make sure you have `header.jpg` or `thumb.jpg`
-- Check for multiple files with those names (delete duplicates)
+**"The wrong image shows up as thumbnail"**
+- Make sure you have exactly one file named `header.jpg` or `thumb.jpg`
 
 **"My categories don't appear in filters"**
-- Categories must be in the frontmatter `categories:` list
-- Format: ALL CAPS
-- Rebuild the site to update filters
+- Categories update after the next site rebuild (3–5 min after saving)
 
 See [Common Issues](../06-troubleshooting/common-issues.md) for more help.
 
 ---
 
-## Next Steps
-
-- **[Add News, Awards, etc.](adding-news-awards.md)** - Add non-project entries
-- **[Image Guide](image-guide.md)** - Best practices for images
-- **[Frontmatter Reference](frontmatter-reference.md)** - Complete field guide
-- **[Making Commits](../05-tools-and-workflow/making-commits.md)** - Publish your changes
-
----
-
-## Questions?
-
-See the [FAQ](../06-troubleshooting/faq.md) or ask a team member for help.
+> **Advanced: How it works under the hood**
+>
+> When you save in the admin panel, it writes a markdown file to `entries/projects/{slug}/{slug}.md` on GitHub with your content in [frontmatter](frontmatter-reference.md) format. The build system (Eleventy) discovers the file automatically and generates the project page and index entry. You can edit these files directly on GitHub if you need to make changes the admin panel doesn't support — see [Frontmatter Reference](frontmatter-reference.md) for the full field list.

--- a/docs/02-adding-content/adding-news-awards.md
+++ b/docs/02-adding-content/adding-news-awards.md
@@ -1,471 +1,93 @@
 # How to Add News, Awards, and Other Updates
 
-Step-by-step guide for adding non-project entries (news, awards, features, lectures, exhibitions, staff updates).
-
----
-
-## Editing Options
-
-You can add entries in three ways:
-
-### Option 1: Admin Panel (Easiest)
-
-Use the password-protected admin at `/admin/`:
-- ✅ No files to create manually
-- ✅ Works in any browser
-- ✅ Inline editing for all fields
-- ✅ See [Using the Admin Panel](../08-admin/using-the-admin.md)
-
-### Option 2: GitHub Web Editor (No Installation)
-
-Use GitHub.com to create files directly in your browser:
-- ✅ No software to install
-- ✅ Works on any device
-- ✅ Can use AI assistants for help
-- ✅ See [GitHub Web Editor Guide](../05-tools-and-workflow/github-web-editor.md)
-
-**This guide shows the web editor workflow first, then local editing.**
-
-### Option 2: Local Development (Advanced)
-
-Install VS Code and edit files on your computer:
-- ⚡ Faster feedback
-- ⚡ Local preview
-- ⚡ Better for complex changes
-- ⚡ See [Code Editor Setup](../05-tools-and-workflow/code-editor-setup.md)
+Non-project entries (news, awards, features, lectures, exhibitions, staff) appear in the comprehensive index at `/all/` but do not get their own detail pages.
 
 ---
 
 ## Entry Types
 
-These entry types appear ONLY in the comprehensive index (they don't get their own pages):
-
-- **News** - Studio announcements and updates
-- **Awards** - Honors and recognitions
-- **Features** - Press coverage and publications
-- **Lectures** - Talks, presentations, speaking engagements
-- **Exhibitions** - Gallery shows and installations
-- **Staff** - Team updates (new hires, departures, promotions)
-
----
-
-## Difference from Projects
-
-| Aspect | Projects | Updates (News, Awards, etc.) |
-|--------|----------|------------------------------|
-| **Get own page?** | ✅ Yes (`/project/{name}/`) | ❌ No (index only) |
-| **Gallery** | ✅ Multiple images | ❌ Thumbnail only |
-| **External links** | ❌ Internal only | ✅ Can link out |
-| **Collaborators** | ✅ Has collaborators field | ❌ No collaborators |
-| **Description** | Short summary | Shows in index Column 3 |
+| Type | Use for |
+|------|---------|
+| **news** | Studio announcements, partnerships, office updates |
+| **award** | Design awards, competition wins, professional honors |
+| **feature** | Magazine articles, podcast appearances, book mentions |
+| **lecture** | University talks, conference presentations, workshops |
+| **exhibition** | Art installations, gallery shows, museum exhibitions |
+| **staff** | New hires, promotions, departures |
 
 ---
 
-## Web Editor Workflow
+## Step 1: Open the Admin Panel
 
-### Step 1: Go to GitHub.com
-
-1. Navigate to https://github.com/lowdo-bay/lowdo-dot-net
-2. All non-project entries go in the same folder: `entries/other/`
-
-### Step 2: Create the Entry File
-
-1. Click **"Add file"** → **"Create new file"**
-2. In the name field, type the full path:
-   ```
-   your-entry-name/your-entry-name.md
-   ```
-
-**Naming Rules:**
-- Lowercase letters only
-- Hyphens instead of spaces
-- Be descriptive
-
-✅ Good: `emerging-voices-award/emerging-voices-award.md`
-❌ Bad: `Award 1/Award 1.md`, `new_award/new_award.md`
-
-### Step 3: Add Entry Information
-
-Copy this template and fill in your details:
-
-```yaml
----
-draft: false
-type: award
-title: "Emerging Voices Award"
-subtitle: "Architectural League of New York"
-date: 2021-12-31
-categories:
-  - AWARD
-  - PRESS
-link: "https://archleague.org/article/emerging-voices-2022/"
-description: "LowDO selected for the prestigious Emerging Voices program"
----
-
-Optional: Write a longer description here. This appears below the entry in the comprehensive index when expanded.
-
-You can add details about the award, news, or event.
-```
-
-### Step 4: Commit the File
-
-1. Scroll down to "Commit changes"
-2. Write a commit message: `Add [Entry Title]`
-3. Select **"Create a new branch for this commit and start a pull request"**
-4. Click "Propose changes"
-5. Click "Create pull request"
-
-### Step 5: Upload Thumbnail Image (Optional)
-
-1. Navigate to your entry folder: `entries/other/your-entry-name/`
-2. Click **"Add file"** → **"Upload files"**
-3. Upload an image named `thumb.jpg` or `header.jpg`
-4. Make sure to **commit to the same branch** you created earlier
-5. Write commit message: `Add thumbnail for [Entry Title]`
-6. Click "Commit changes"
-
-### Step 6: Wait for Preview, Test, and Merge
-
-1. Go back to your pull request
-2. Wait 3-5 minutes for Netlify preview
-3. Click "Details" on the "netlify/deploy-preview" check
-4. Navigate to `/all/` to see your entry in the index
-5. If everything looks good, click **"Merge pull request"**
-6. Click **"Confirm merge"**
-
-**Your entry goes live in 3-5 minutes!**
+Go to `/admin/` and log in. Click **+ New Entry** in the top-right corner.
 
 ---
 
-## Local Development Workflow
+## Step 2: Fill In the Details
 
-### Step 1: Choose the Right Folder
+Click **Edit** on the new row to open the side panel. Fill in:
 
-All non-project entries go in `entries/other/`. The entry type is set by the `type:` field in the file, not by its folder.
+| Field | Required | Notes |
+|-------|----------|-------|
+| Title | ✅ | Entry heading |
+| Type | ✅ | news, award, feature, lecture, exhibition, or staff |
+| Date | ✅ | When this happened |
+| Subtitle | — | Short tagline shown below the title |
+| Description | — | 1–2 sentence summary shown in the index |
+| Categories | — | Topic tags (e.g. AWARD, PRESS, LECTURE) |
+| Link | — | External URL — makes the title clickable |
+| Related Projects | — | Links this entry to one or more project pages |
 
----
-
-### Step 2: Create a Folder
-
-Create a new folder inside `entries/other/` with a descriptive name.
-
-**Naming rules:**
-- Lowercase letters only
-- Hyphens instead of spaces
-- Be descriptive
-
-✅ Good: `emerging-voices-award`, `austin-chronicle-feature`, `ut-lecture-2024`
-❌ Bad: `Award 1`, `new_award`, `EMERGING VOICES`
-
-**Example:**
-```
-entries/other/emerging-voices-award/
-```
+Click **Apply Changes** when done.
 
 ---
 
-### Step 3: Create a Markdown File
+## Step 3: Save
 
-Inside the folder, create a `.md` file with the **same name** as the folder.
-
-✅ Correct:
-```
-emerging-voices-award/
-└── emerging-voices-award.md
-```
-
-❌ Wrong:
-```
-emerging-voices-award/
-└── award.md
-```
+Click **Save Changes** (top right). The site rebuilds in 3–5 minutes and the entry appears in the index at `/all/`.
 
 ---
 
-### Step 4: Add Entry Information
+## Step 4: Add a Thumbnail (Optional)
 
-Copy this template and fill in your details:
+Thumbnails are uploaded directly to GitHub:
 
-```yaml
----
-draft: false
-type: award
-title: "Emerging Voices Award"
-subtitle: "Architectural League of New York"
-date: 2021-12-31
-categories:
-  - AWARD
-  - PRESS
-link: "https://archleague.org/article/emerging-voices-2022/"
-description: "LowDO selected for the prestigious Emerging Voices program"
----
-
-Optional: You can write more details here, but they won't appear in the index.
-This is useful for keeping records or adding context.
-```
+1. Go to [github.com/lowdo-bay/lowdo-dot-net](https://github.com/lowdo-bay/lowdo-dot-net)
+2. Navigate to `entries/other/{your-entry-slug}/`
+3. Click **Add file → Upload files**
+4. Upload an image named `header.jpg` or `thumb.jpg`
 
 ---
 
-### Step 5: Add an Image (Optional)
+## Linking to Projects
 
-Drop a thumbnail image in the folder.
-
-Name it `header.jpg` or `thumb.jpg`:
-
-```
-entries/other/emerging-voices-award/
-├── emerging-voices-award.md
-└── thumb.jpg                    ← Optional thumbnail
-```
-
----
-
-### Step 6: Save and Publish
-
-Save the `.md` file and commit your changes with git.
-
-See [Making Commits](../05-tools-and-workflow/making-commits.md) for details.
-
----
-
-## Required Fields
-
-| Field | What It Does | Example |
-|-------|-------------|---------|
-| `draft: false` | Visibility (`false` = published) | `draft: false` |
-| `title: "..."` | Main heading | `title: "Emerging Voices Award"` |
-| `date: YYYY-MM-DD` | When this happened | `date: 2021-12-31` |
-
----
-
-## Optional Fields
-
-| Field | What It Does | Example |
-|-------|-------------|---------|
-| `subtitle: "..."` | Tagline below title | `subtitle: "Architectural League"` |
-| `categories: [...]` | Topic tags (all caps) | `categories:`<br>`  - AWARD` |
-| `link: "https://..."` | External URL (makes title clickable) | `link: "https://example.com"` |
-| `description: "..."` | Summary shown in Column 3 | `description: "LowDO selected..."` |
-| `position: number` | Sort order (lower = first) | `position: 1` |
-
----
-
-## Key Differences from Projects
-
-### The `link` Field
-
-For updates, the `link` field makes the title clickable and opens in a new tab:
-
-```yaml
-link: "https://archleague.org/article/emerging-voices/"
-```
-
-This is perfect for:
-- Awards with ceremony announcements
-- Press features on external sites
-- Lecture event pages
-- Exhibition gallery websites
-
-### The `description` Field
-
-For updates, the `description` appears in Column 3 of the index:
-
-```yaml
-description: "LowDO selected for the prestigious Emerging Voices program recognizing emerging architecture studios."
-```
-
-Keep it concise (1-2 sentences).
-
-### No Collaborators
-
-Updates don't have a `collaborators:` field. That's only for projects.
-
-### The `relatedProjects` Field
-
-You can link an award, feature, news, lecture, exhibition, or staff update to one or more projects. Each linked project will show the entry in its "Awards & Recognition" section.
-
-```yaml
-relatedProjects:
-  - wolf-creek-ranch
-```
-
-Use the **project folder name** (the slug) for each entry. For example:
-```yaml
-relatedProjects:
-  - casa-marianella
-  - river-house
-  - garden-st-residence
-```
-
-**Example:** An award linked to multiple projects
-
-```yaml
----
-draft: false
-title: "Design Excellence Award"
-subtitle: "American Institute of Architects"
-date: 2024-05-15
-categories:
-  - AWARD
-relatedProjects:
-  - wolf-creek-ranch
-  - casa-marianella
-link: "https://example.com"
-description: "Recognized for exceptional design and sustainability"
----
-```
-
-The award will appear in the "Awards & Recognition" section of both project pages.
-
----
-
-## When to Use Which Type
-
-### News
-General studio announcements:
-- Studio expansion
-- New services
-- Partnerships
-- Office moves
-
-### Awards
-Honors and recognitions:
-- Design awards
-- Competitions won
-- Professional honors
-- Grant recipients
-
-### Features
-When LowDO is featured externally:
-- Magazine articles
-- Blog posts
-- Podcast appearances
-- Book mentions
-
-### Lectures
-Talks and presentations:
-- University lectures
-- Conference talks
-- Panel discussions
-- Workshops
-
-### Exhibitions
-Gallery shows and installations:
-- Art installations
-- Design exhibitions
-- Museum shows
-- Pop-up displays
-
-### Staff
-Team updates:
-- New hires
-- Promotions
-- Departures
-- Anniversaries
-
----
-
-## Examples
-
-### Award Example
-
-```yaml
----
-draft: false
-title: "AIA Design Award"
-subtitle: "American Institute of Architects"
-date: 2024-05-15
-categories:
-  - AWARD
-  - ARCHITECTURE
-link: "https://www.aia.org/awards/2024"
-description: "Casa Marianella project receives AIA Design Award for community impact"
----
-```
-
-### Feature Example
-
-```yaml
----
-draft: false
-title: "Austin Chronicle Feature"
-subtitle: "Designing for Community"
-date: 2024-03-20
-categories:
-  - PRESS
-  - FEATURE
-link: "https://www.austinchronicle.com/arts/2024-03-20/lowdo/"
-description: "Profile of LowDO's community-centered design approach"
----
-```
-
-### Lecture Example
-
-```yaml
----
-draft: false
-title: "UT Architecture Lecture Series"
-subtitle: "Sustainable Urbanism"
-date: 2024-02-10
-categories:
-  - LECTURE
-  - EDUCATION
-link: "https://soa.utexas.edu/events/lecture-series"
-description: "Presentation on sustainable design strategies for urban housing"
----
-```
+Use **Related Projects** to make an award, feature, or news item appear in a project's "Awards & Recognition" section. In the edit panel, type the project slug to search and add it.
 
 ---
 
 ## Tips
 
-**Categories:**
-- For awards, include "AWARD"
-- For press, include "PRESS" or "FEATURE"
-- For lectures, include "LECTURE"
-- See [Category Guidelines](../07-reference/category-guidelines.md)
+**External links** — The `link` field makes the title clickable and opens in a new tab. Always use full URLs starting with `https://`. Useful for awards with announcement pages, press on external sites, event pages.
 
-**External Links:**
-- Always use full URLs starting with `https://`
-- Test links to make sure they work
-- Prefer long-term stable URLs (not temporary event pages)
+**Descriptions** — Keep it to 1–2 sentences. This text appears in Column 3 of the index.
 
-**Descriptions:**
-- Keep it to 1-2 sentences
-- Focus on what happened and why it matters
-- Avoid jargon
+**Categories** — Use consistent categories to keep filters useful. Common ones: `AWARD`, `PRESS`, `LECTURE`, `EXHIBITION`. See [Category Guidelines](../07-reference/category-guidelines.md).
 
 ---
 
 ## Troubleshooting
 
-**"My entry doesn't appear"**
-- Check `draft: false`
-- Check file/folder naming (must match)
-- Check date format (YYYY-MM-DD)
+**"My entry doesn't appear in the index"**
+- Check that the draft toggle is grey (published), not red
+- Wait 3–5 minutes for the rebuild after saving
 
 **"The link doesn't work"**
-- Check URL starts with `https://`
-- Check for typos in the URL
-- Test the link in a browser
-
-**"No thumbnail shows up"**
-- Add `header.jpg` or `thumb.jpg` to the folder
-- Check image file extension (`.jpg`, `.png`)
+- Make sure it starts with `https://`
 
 See [Common Issues](../06-troubleshooting/common-issues.md) for more help.
 
 ---
 
-## Next Steps
-
-- **[Adding a Project](adding-a-project.md)** - For design projects
-- **[Image Guide](image-guide.md)** - Image best practices
-- **[Frontmatter Reference](frontmatter-reference.md)** - All available fields
-- **[Entry Types Comparison](../07-reference/entry-types-comparison.md)** - Quick reference
-
----
-
-## Questions?
-
-See the [FAQ](../06-troubleshooting/faq.md) or ask a team member.
+> **Advanced: How it works under the hood**
+>
+> The admin panel writes a markdown file to `entries/other/{slug}/{slug}.md` on GitHub. The `type:` field in the frontmatter determines how it's displayed in the index. You can edit these files directly on GitHub — see [Frontmatter Reference](frontmatter-reference.md) for the full field list.

--- a/docs/03-editing-content/editing-existing-entries.md
+++ b/docs/03-editing-content/editing-existing-entries.md
@@ -1,73 +1,60 @@
 # Editing Existing Entries
 
-How to modify published content.
+All content edits are done through the Admin Panel at `/admin/`.
 
 ---
 
-## Step 1: Find the File
+## How to Edit an Entry
 
-Navigate to the entry folder:
+1. Go to `/admin/` and log in
+2. Find the entry in the table — use the search box or type filters to narrow it down
+3. Click **Edit** on the row
+4. Make your changes in the side panel
+5. Click **Apply Changes**
+6. Click **Save Changes** (top right) to commit everything to GitHub
 
-```
-entries/projects/casa-marianella/casa-marianella.md
-```
-
-Or:
-
-```
-entries/news/studio-expansion/studio-expansion.md
-```
-
----
-
-## Step 2: Open and Edit
-
-Open the .md file in your editor and make changes:
-
-- Edit frontmatter (title, date, categories)
-- Edit content below the frontmatter
-- Add/remove/replace images
-
----
-
-## Step 3: Save and Publish
-
-1. Save the file
-2. Commit: `git add . && git commit -m "Update entry"`
-3. Push: `git push`
+The site rebuilds automatically in 3–5 minutes.
 
 ---
 
 ## What You Can Edit
 
-**Frontmatter:**
-- title, subtitle, description
-- date (changes sort order)
-- categories (changes filters)
-- draft status (hide/show)
+**In the side panel:**
+- Title, subtitle, description
+- Date (affects sort order)
+- Link (external URL)
+- Categories (also editable inline in the table row)
+- Type (also editable inline)
+- Draft status (also togglable via the dot in the table row)
+- Body text (project description, written in markdown)
+- Collaborators (projects only)
+- Related projects (non-projects only)
 
-**Content:**
-- Project descriptions
-- Markdown text
-- Headings and formatting
-
-**Images:**
-- Replace images (keep same filename)
-- Add new gallery images
-- Remove images (delete files)
+**Not editable in the admin panel:**
+- The entry slug (URL path) — contact Bay or ask an AI assistant if you need to rename an entry
+- Images — upload/replace images directly on [GitHub](https://github.com/lowdo-bay/lowdo-dot-net) in the entry's folder
 
 ---
 
-## Tips
+## Editing Categories Inline
 
-- Test locally if possible
-- Make one change at a time
-- Write clear commit messages
+You don't need to open the edit panel to change categories:
+
+- Click **×** on a tag in the table row to remove it
+- Click **+** to add a category (opens a searchable dropdown)
+- Type a new name to create one that doesn't exist yet
+
+---
+
+## Saving
+
+All changes are held in memory until you click **Save Changes**. The counter in the top-right shows how many entries have pending changes. Changes are committed to GitHub in a single operation — you can edit multiple entries before saving.
+
+⚠️ If you leave the tab or the session expires (24 hours), unsaved changes are lost.
 
 ---
 
 ## Next Steps
 
-- [Hiding/Unpublishing](hiding-unpublishing.md)
-- [Organizing Entries](organizing-entries.md)
-
+- [Hiding/Unpublishing Content](hiding-unpublishing.md) — Make an entry invisible without deleting it
+- [Organizing Entries](organizing-entries.md) — Sort order and categories

--- a/docs/03-editing-content/hiding-unpublishing.md
+++ b/docs/03-editing-content/hiding-unpublishing.md
@@ -1,42 +1,40 @@
 # Hiding/Unpublishing Content
 
-How to remove content from the site without deleting it.
+You can hide an entry from the public site without deleting it, so you can restore it later.
 
 ---
 
-## Using draft: true
+## How to Hide an Entry
 
-Set `draft: true` in frontmatter to hide an entry:
+In the admin panel, click the **dot** in the Draft column of the entry's row:
 
-```yaml
----
-draft: true
-title: "My Project"
----
-```
+- **Red dot** = draft (hidden from public)
+- **Grey dot** = published (visible on public site)
 
-The entry won't appear in the index or have a public page.
+Click the dot to toggle between states. Then click **Save Changes** to apply.
+
+The entry remains visible in the admin table at all times — only the public site is affected.
 
 ---
 
 ## When to Use
 
-- Work in progress
-- Outdated content
-- Seasonal content
-- Testing before publishing
+- Work in progress not ready to publish
+- Outdated content you might want to restore later
+- Seasonal content (events, exhibitions)
+- Testing changes before going live
 
 ---
 
-## To Unhide
+## Permanently Removing an Entry
 
-Set back to `draft: false` and push.
+To delete an entry entirely:
 
----
+1. Click **Del** on the row in the admin panel
+2. Confirm in the dialog
+3. Click **Save Changes**
 
-## Alternative: Delete
-
-To permanently remove, delete the entire folder and commit.
+⚠️ Deletion cannot be undone after saving. The entry folder and all its files (including images) are permanently removed from GitHub.
 
 ---
 
@@ -44,4 +42,3 @@ To permanently remove, delete the entire folder and commit.
 
 - [Editing Existing Entries](editing-existing-entries.md)
 - [Organizing Entries](organizing-entries.md)
-

--- a/docs/03-editing-content/organizing-entries.md
+++ b/docs/03-editing-content/organizing-entries.md
@@ -1,66 +1,53 @@
 # Organizing Entries
 
-Managing categories, dates, and sort order.
+How to control sort order and categories.
 
 ---
 
 ## Sort Order
 
-Entries are sorted by:
+Entries in the index are sorted by:
 
-1. `position` field (if set, lower = first)
+1. `position` field (if set — lower number = appears first)
 2. `date` field (newest first)
 
----
-
-## Using position
-
-Override date sorting:
-
-```yaml
-position: 1  # Appears first
-```
+To pin an entry to the top, open it in the admin panel and set the **Position** field to `1`. To remove pinning, clear the field.
 
 ---
 
 ## Categories
 
-Use existing categories when possible. Common categories include:
+Categories are the tags used to filter entries in the index. Use existing categories when possible to keep filters organized.
 
-```yaml
-categories:
-  - HOUSING        # Residential projects
-  - COMMERCIAL     # Commercial/hospitality
-  - COMMUNITY      # Civic projects (schools, hospitals, public)
-  - SUSTAINABLE    # Sustainability-focused
-  - AFRICA         # Work on African continent
-  - BAMBOT         # Bamboo robotic construction
-  - INSTALLATION   # Temporary structures, exhibitions
-  - AMP            # Agbogbloshie Makerspace Platform
-```
+Common categories:
 
-See [Category Guidelines](../07-reference/category-guidelines.md) for the complete list.
+- `HOUSING` — Residential projects
+- `COMMERCIAL` — Commercial / hospitality
+- `COMMUNITY` — Civic projects (schools, hospitals, public spaces)
+- `SUSTAINABLE` — Sustainability-focused work
+- `INSTALLATION` — Temporary structures, exhibitions
+- `AWARD`, `PRESS`, `LECTURE` — For non-project entries
 
-### Renaming or Reorganizing Categories
+See [Category Guidelines](../07-reference/category-guidelines.md) for the full list.
 
-The easiest way to rename or consolidate categories is through the **admin panel**:
+### Adding or Removing Categories
 
-1. Go to `/admin/` and log in
-2. Click **Manage Labels** in the toolbar
-3. Under the **Categories** tab, click **Rename** next to any category
-4. Type the new name and press Enter or click Save
-5. All entries with that category are updated automatically
-6. Click **Save Changes** to commit everything to GitHub
+In the admin table, click **+** or **×** directly on the category tags in any row — no need to open the edit panel.
 
-See [Using the Admin Panel](../08-admin/using-the-admin.md) for full details.
+### Renaming Categories Across All Entries
+
+1. Go to `/admin/` and click **Manage Labels** in the toolbar
+2. Select the **Categories** tab
+3. Click **Rename** next to the category you want to change
+4. Type the new name and press Enter
+5. All entries are updated automatically in memory
+6. Click **Save Changes** to commit
 
 ---
 
 ## Dates
 
-Format: YYYY-MM-DD
-
-Changes sort order and display.
+The `date` field controls sort order when no `position` is set. Edit it in the side panel for any entry. Format: `YYYY-MM-DD`.
 
 ---
 
@@ -68,4 +55,3 @@ Changes sort order and display.
 
 - [Category Guidelines](../07-reference/category-guidelines.md)
 - [Editing Existing Entries](editing-existing-entries.md)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,97 +1,35 @@
 # LowDO Website Documentation
 
-Welcome to the LowDO website. This guide will help you get oriented and start editing content.
+Welcome to the LowDO website. All content is managed through the **Admin Panel** at `/admin/` — no coding, GitHub, or local setup required.
 
 ---
 
-## What Can You Do Without Knowing How to Code?
+## Quick Start
 
-✅ **Add new content** — Design projects, news, awards, press features, lectures, exhibitions, staff updates
-✅ **Edit existing content** — Update descriptions, dates, categories, metadata, hide content
-✅ **Customize the site** — Change colors, themes, site title, contact information
-✅ **Publish changes** — Save and deploy to the live site (no manual builds)
-
-❌ **What you CAN'T do easily** — Change layout/structure, add new features, modify code (ask an AI assistant for these)
-
----
-
-## What You'll Need
-
-- Web browser (Chrome, Firefox, Safari, etc.)
-- GitHub account with access to the lowdo-dot-net repository
-- This documentation
-
-**Most people can edit everything using just their web browser!**
-
----
-
-## How the Site Works
-
-LowDO is a **static site**, meaning content lives in text files (not a database like WordPress). When you add or edit files, the system automatically discovers them, generates pages, and updates the index.
-
-### The Workflow
-
-```
-You create/edit files on GitHub
-        ↓
-Netlify detects changes
-        ↓
-Eleventy build system runs (3-5 min)
-        ↓
-Site rebuilds with your content
-        ↓
-Changes go live at lowdo.netlify.app
-```
-
-### Content Types
-
-**Projects** — Get their own detail pages with image galleries
-- Folder: `entries/projects/{project-name}/`
-- URL: `/project/{project-name}/`
-
-**Updates** — Appear in the index at `/all/`, no individual pages
-- News, awards, features, lectures, exhibitions, staff
-- Folder: `entries/other/{entry-name}/`
-
-### What's Automatic
-
-- File discovery — add a file and it appears on the site
-- Image discovery — drop images in a folder and they're added to the gallery
-- Index updates — comprehensive index automatically shows new entries
-- Image optimization — images are automatically resized and compressed
-
-### Files You Edit
-
-- `entries/` — All content (projects, news, awards, etc.)
-- `_data/settings.yaml` — Site colors, title, contact info
-
-**Don't touch:** `_includes/` (templates and code) or `_site/` (auto-generated output).
+1. Go to [lowdo.netlify.app/admin](https://lowdo.netlify.app/admin/)
+2. Enter the admin password (contact Bay if you need it)
+3. Use the table to add, edit, and publish entries
+4. Click **Save Changes** — the site rebuilds automatically in 3–5 minutes
 
 ---
 
 ## Adding Content
 
-- [How to Add a Project](02-adding-content/adding-a-project.md) — Complete guide with file naming conventions
-- [How to Add News, Awards, & More](02-adding-content/adding-news-awards.md) — Festivals, lectures, exhibitions, and staff updates
+- [How to Add a Project](02-adding-content/adding-a-project.md) — Design projects with galleries and detail pages
+- [How to Add News, Awards, & More](02-adding-content/adding-news-awards.md) — Announcements, press, lectures, exhibitions, staff updates
 - [Image Guide](02-adding-content/image-guide.md) — Best practices for image naming and uploading
 - [Frontmatter Reference](02-adding-content/frontmatter-reference.md) — Complete field guide
 
 ## Editing & Customizing
 
-- [Editing Existing Entries](03-editing-content/editing-existing-entries.md) — Update, hide, or reorganize content
-- [Customizing the Site](04-customizing-the-site/changing-colors.md) — Change colors, title, contact info
-- [GitHub Web Editor](05-tools-and-workflow/github-web-editor.md) — Edit files in your browser (no installation)
-
-## Tools & Workflow
-
-- [Git for Beginners](05-tools-and-workflow/git-for-beginners.md) — Version control basics
-- [Making Commits](05-tools-and-workflow/making-commits.md) — How to save and publish changes
-- [Local Development](05-tools-and-workflow/code-editor-setup.md) — VS Code setup and preview
-- [Using AI Assistants](05-tools-and-workflow/using-ai-assistants.md) — How to get help from Claude, ChatGPT, etc.
+- [Editing Existing Entries](03-editing-content/editing-existing-entries.md) — Update, hide, or delete content
+- [Hiding/Unpublishing Content](03-editing-content/hiding-unpublishing.md) — Make entries invisible without deleting them
+- [Organizing Entries](03-editing-content/organizing-entries.md) — Sort order and categories
+- [Customizing the Site](04-customizing-the-site/changing-colors.md) — Colors, title, contact info
 
 ## Admin Panel
 
-- [Using the Admin Panel](08-admin/using-the-admin.md) — Manage entries, edit fields, rename categories/types, and publish changes
+- [Using the Admin Panel](08-admin/using-the-admin.md) — Full reference for all admin features
 
 ## Help & Reference
 


### PR DESCRIPTION
Rewrite adding-a-project, adding-news-awards, editing-existing-entries, hiding-unpublishing, organizing-entries, and README to lead with the admin panel. GitHub/local file editing moved to advanced callouts only.