### PR TITLE
Add create new type/category to Manage Labels modal

### DIFF
--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -816,12 +816,17 @@ body {
   outline: none;
 }
 
-.manage-create-input { text-transform: none; }
-.manage-create-row td { border-top: 1px dashed var(--admin-border); }
+.manage-create-input { text-transform: none; flex: 1; min-width: 0; }
+.manage-footer__create {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1;
+  margin: 0 1rem;
+}
 .manage-create-error {
   font-size: 10px;
   color: var(--admin-danger, #c0392b);
-  margin-left: 4px;
   white-space: nowrap;
 }
 

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -641,6 +641,7 @@ body {
   position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.3);
+  overscroll-behavior: contain;
   display: none;
   align-items: center;
   justify-content: center;

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -489,10 +489,10 @@ body {
 }
 
 /* Full-height vertical column dividers — anchored to th, extend full page height */
-.admin-table thead th:not(:last-child) {
+.admin-table:not(.manage-table) thead th:not(:last-child) {
   overflow: visible;
 }
-.admin-table thead th:not(:last-child)::before {
+.admin-table:not(.manage-table) thead th:not(:last-child)::before {
   content: '';
   position: absolute;
   top: 0;

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -778,7 +778,7 @@ body {
 .manage-tab:hover { color: var(--admin-text); }
 .manage-tab.is-active { color: var(--admin-primary); border-bottom-color: var(--admin-primary); font-weight: 600; }
 
-.manage-panel { overflow-y: auto; }
+.manage-panel { overflow-y: auto; flex: 0 1 auto; min-height: 0; }
 
 /* Table columns */
 .manage-table { table-layout: fixed; }

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -816,7 +816,7 @@ body {
   outline: none;
 }
 
-.manage-create-input { text-transform: none; flex: 1; min-width: 0; }
+.manage-create-input { text-transform: none; flex: 1; min-width: 0; padding: 0.4rem 0.75rem; font-size: 12px; }
 .manage-footer__create {
   display: flex;
   align-items: center;

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -816,6 +816,15 @@ body {
   outline: none;
 }
 
+.manage-create-input { text-transform: none; }
+.manage-create-row td { border-top: 1px dashed var(--admin-border); }
+.manage-create-error {
+  font-size: 10px;
+  color: var(--admin-danger, #c0392b);
+  margin-left: 4px;
+  white-space: nowrap;
+}
+
 .manage-footer {
   display: flex;
   align-items: center;

--- a/_includes/assets/css/admin.css
+++ b/_includes/assets/css/admin.css
@@ -636,12 +636,13 @@ body {
 .category-dropdown li.is-new { font-style: italic; color: var(--admin-primary); }
 .category-dropdown li.is-new::before { content: '+ Create '; font-style: normal; }
 
+body.modal-open { overflow: hidden; }
+
 /* Modal */
 .modal {
   position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.3);
-  overscroll-behavior: contain;
   display: none;
   align-items: center;
   justify-content: center;

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -203,6 +203,14 @@
     adminScreen.hidden = false;
     if (!adminInitialized) {
       adminInitialized = true;
+      // Lock body scroll whenever any modal is open
+      var modalObserver = new MutationObserver(function() {
+        var anyOpen = !!document.querySelector('.modal:not([hidden])');
+        document.body.classList.toggle('modal-open', anyOpen);
+      });
+      document.querySelectorAll('.modal').forEach(function(m) {
+        modalObserver.observe(m, { attributes: true, attributeFilter: ['hidden'] });
+      });
       buildTypeFilters();
       buildCategoryFilters();
       // Set initial sort indicator

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -2415,6 +2415,26 @@
 
   // ---- Manage labels modal (rename categories + types) ----
 
+  function createCategory(name) {
+    var normalized = name.trim().toUpperCase();
+    if (!normalized) return 'Enter a name.';
+    if (canonicalCategories.indexOf(normalized) !== -1) return 'Already exists.';
+    canonicalCategories.push(normalized);
+    canonicalCategoriesChanged = true;
+    updateChanges();
+    return null;
+  }
+
+  function createType(name) {
+    var normalized = name.trim().toLowerCase();
+    if (!normalized) return 'Enter a name.';
+    if (normalized === 'project') return 'Reserved name.';
+    if (knownTypes.indexOf(normalized) !== -1) return 'Already exists.';
+    knownTypes.push(normalized);
+    updateChanges();
+    return null;
+  }
+
   function renameCategory(oldName, newName) {
     newName = newName.trim().toUpperCase();
     if (!newName || newName === oldName) return;
@@ -2503,7 +2523,7 @@
     renderTable();
   }
 
-  function renderManageList(tbody, items, onRename, onDelete, isCategories, onSelectionChange) {
+  function renderManageList(tbody, items, onRename, onDelete, isCategories, onSelectionChange, onCreate) {
     tbody.innerHTML = '';
     items.forEach(function(name) {
       // Count entries using this label
@@ -2616,6 +2636,58 @@
       tr.appendChild(tdActions);
       tbody.appendChild(tr);
     });
+
+    // Creation row
+    if (onCreate) {
+      var createRow = document.createElement('tr');
+      createRow.className = 'manage-create-row';
+
+      var createTdEmpty = document.createElement('td');
+      createRow.appendChild(createTdEmpty);
+
+      var createTdInput = document.createElement('td');
+      createTdInput.className = 'manage-col-label';
+      var createInput = document.createElement('input');
+      createInput.type = 'text';
+      createInput.className = 'manage-list-input manage-create-input';
+      createInput.placeholder = isCategories ? 'New category\u2026' : 'New type\u2026';
+      createTdInput.appendChild(createInput);
+      createRow.appendChild(createTdInput);
+
+      var createTdCount = document.createElement('td');
+      createRow.appendChild(createTdCount);
+
+      var createTdActions = document.createElement('td');
+      createTdActions.className = 'manage-col-actions';
+      var createBtn = document.createElement('button');
+      createBtn.className = 'btn btn--small btn--secondary';
+      createBtn.textContent = '+ Create';
+      var createError = document.createElement('span');
+      createError.className = 'manage-create-error';
+      createTdActions.appendChild(createBtn);
+      createTdActions.appendChild(createError);
+      createRow.appendChild(createTdActions);
+
+      tbody.appendChild(createRow);
+
+      function doCreate() {
+        var err = onCreate(createInput.value);
+        if (err) {
+          createError.textContent = err;
+          createInput.addEventListener('input', function clear() {
+            createError.textContent = '';
+            createInput.removeEventListener('input', clear);
+          });
+          return;
+        }
+        createInput.value = '';
+      }
+
+      createBtn.addEventListener('click', doCreate);
+      createInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') doCreate();
+      });
+    }
   }
 
   function getSelectedManageNames(tbody) {
@@ -2637,25 +2709,39 @@
   }
 
   function openManageModal() {
+    function renderCategories() {
+      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn, onCategoryCreate);
+      updateCombineBtn();
+    }
+    function renderTypes() {
+      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn, onTypeCreate);
+      updateCombineBtn();
+    }
     function onCategoryRename(oldName, newName) {
       renameCategory(oldName, newName.toUpperCase());
-      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
-      updateCombineBtn();
+      renderCategories();
     }
     function onCategoryDelete(name) {
       deleteCategory(name);
-      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
-      updateCombineBtn();
+      renderCategories();
+    }
+    function onCategoryCreate(name) {
+      var err = createCategory(name);
+      if (!err) renderCategories();
+      return err;
     }
     function onTypeRename(oldName, newName) {
       renameType(oldName, newName.toLowerCase());
-      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
-      updateCombineBtn();
+      renderTypes();
     }
     function onTypeDelete(name) {
       deleteType(name);
-      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
-      updateCombineBtn();
+      renderTypes();
+    }
+    function onTypeCreate(name) {
+      var err = createType(name);
+      if (!err) renderTypes();
+      return err;
     }
 
     function combineSelected() {
@@ -2683,7 +2769,7 @@
           seen[c] = true;
           return true;
         });
-        renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
+        renderCategories();
       } else {
         var seenT = {};
         knownTypes = knownTypes.filter(function(t) {
@@ -2691,15 +2777,14 @@
           seenT[t] = true;
           return true;
         });
-        renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
+        renderTypes();
       }
-      updateCombineBtn();
     }
 
     manageCombineBtn.onclick = combineSelected;
 
-    renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
-    renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
+    renderCategories();
+    renderTypes();
     manageCombineBtn.hidden = true;
     manageModal.hidden = false;
   }

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -2523,7 +2523,7 @@
     renderTable();
   }
 
-  function renderManageList(tbody, items, onRename, onDelete, isCategories, onSelectionChange, onCreate) {
+  function renderManageList(tbody, items, onRename, onDelete, isCategories, onSelectionChange) {
     tbody.innerHTML = '';
     items.forEach(function(name) {
       // Count entries using this label
@@ -2637,57 +2637,6 @@
       tbody.appendChild(tr);
     });
 
-    // Creation row
-    if (onCreate) {
-      var createRow = document.createElement('tr');
-      createRow.className = 'manage-create-row';
-
-      var createTdEmpty = document.createElement('td');
-      createRow.appendChild(createTdEmpty);
-
-      var createTdInput = document.createElement('td');
-      createTdInput.className = 'manage-col-label';
-      var createInput = document.createElement('input');
-      createInput.type = 'text';
-      createInput.className = 'manage-list-input manage-create-input';
-      createInput.placeholder = isCategories ? 'New category\u2026' : 'New type\u2026';
-      createTdInput.appendChild(createInput);
-      createRow.appendChild(createTdInput);
-
-      var createTdCount = document.createElement('td');
-      createRow.appendChild(createTdCount);
-
-      var createTdActions = document.createElement('td');
-      createTdActions.className = 'manage-col-actions';
-      var createBtn = document.createElement('button');
-      createBtn.className = 'btn btn--small btn--secondary';
-      createBtn.textContent = '+ Create';
-      var createError = document.createElement('span');
-      createError.className = 'manage-create-error';
-      createTdActions.appendChild(createBtn);
-      createTdActions.appendChild(createError);
-      createRow.appendChild(createTdActions);
-
-      tbody.appendChild(createRow);
-
-      function doCreate() {
-        var err = onCreate(createInput.value);
-        if (err) {
-          createError.textContent = err;
-          createInput.addEventListener('input', function clear() {
-            createError.textContent = '';
-            createInput.removeEventListener('input', clear);
-          });
-          return;
-        }
-        createInput.value = '';
-      }
-
-      createBtn.addEventListener('click', doCreate);
-      createInput.addEventListener('keydown', function(e) {
-        if (e.key === 'Enter') doCreate();
-      });
-    }
   }
 
   function getSelectedManageNames(tbody) {
@@ -2709,12 +2658,16 @@
   }
 
   function openManageModal() {
+    var manageCreateInput = document.getElementById('manage-create-input');
+    var manageCreateBtn = document.getElementById('manage-create-btn');
+    var manageCreateError = document.getElementById('manage-create-error');
+
     function renderCategories() {
-      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn, onCategoryCreate);
+      renderManageList(manageCategoriesList, canonicalCategories.slice(), onCategoryRename, onCategoryDelete, true, updateCombineBtn);
       updateCombineBtn();
     }
     function renderTypes() {
-      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn, onTypeCreate);
+      renderManageList(manageTypesList, knownTypes.slice(), onTypeRename, onTypeDelete, false, updateCombineBtn);
       updateCombineBtn();
     }
     function onCategoryRename(oldName, newName) {
@@ -2725,11 +2678,6 @@
       deleteCategory(name);
       renderCategories();
     }
-    function onCategoryCreate(name) {
-      var err = createCategory(name);
-      if (!err) renderCategories();
-      return err;
-    }
     function onTypeRename(oldName, newName) {
       renameType(oldName, newName.toLowerCase());
       renderTypes();
@@ -2738,11 +2686,24 @@
       deleteType(name);
       renderTypes();
     }
-    function onTypeCreate(name) {
-      var err = createType(name);
-      if (!err) renderTypes();
-      return err;
+
+    function doCreate() {
+      var activeIsCategories = !manageCategoriesPanel.hidden;
+      var err = activeIsCategories ? createCategory(manageCreateInput.value) : createType(manageCreateInput.value);
+      if (err) {
+        manageCreateError.textContent = err;
+        manageCreateInput.addEventListener('input', function clear() {
+          manageCreateError.textContent = '';
+          manageCreateInput.removeEventListener('input', clear);
+        });
+        return;
+      }
+      manageCreateInput.value = '';
+      if (activeIsCategories) renderCategories(); else renderTypes();
     }
+
+    manageCreateBtn.onclick = doCreate;
+    manageCreateInput.onkeydown = function(e) { if (e.key === 'Enter') doCreate(); };
 
     function combineSelected() {
       var activeIsCategories = !manageCategoriesPanel.hidden;
@@ -2786,6 +2747,9 @@
     renderCategories();
     renderTypes();
     manageCombineBtn.hidden = true;
+    manageCreateInput.value = '';
+    manageCreateError.textContent = '';
+    manageCreateInput.placeholder = 'New type\u2026';
     manageModal.hidden = false;
   }
 
@@ -2801,6 +2765,8 @@
     });
     manageCategoriesPanel.hidden = tab !== 'categories';
     manageTypesPanel.hidden = tab !== 'types';
+    var createInput = document.getElementById('manage-create-input');
+    if (createInput) createInput.placeholder = tab === 'categories' ? 'New category\u2026' : 'New type\u2026';
     updateCombineBtn();
   });
 

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -444,6 +444,11 @@ eleventyExcludeFromCollections: true
         </div>
         <div class="manage-footer">
           <p class="manage-hint">Renames and deletes apply when you save changes.</p>
+          <div class="manage-footer__create">
+            <input type="text" id="manage-create-input" class="manage-list-input manage-create-input" placeholder="New type…" />
+            <button id="manage-create-btn" class="btn btn--small btn--secondary">+ Create</button>
+            <span id="manage-create-error" class="manage-create-error"></span>
+          </div>
           <div class="manage-footer__actions">
             <button id="manage-combine-btn" class="btn btn--secondary" hidden>Combine 0 Labels</button>
             <button id="manage-modal-close" class="btn btn--secondary">Done</button>

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -446,7 +446,7 @@ eleventyExcludeFromCollections: true
           <p class="manage-hint">Renames and deletes apply when you save changes.</p>
           <div class="manage-footer__create">
             <input type="text" id="manage-create-input" class="manage-list-input manage-create-input" placeholder="New type…" />
-            <button id="manage-create-btn" class="btn btn--small btn--secondary">+ Create</button>
+            <button id="manage-create-btn" class="btn btn--secondary">+ Create</button>
             <span id="manage-create-error" class="manage-create-error"></span>
           </div>
           <div class="manage-footer__actions">


### PR DESCRIPTION
## Summary
- Adds `[+ Create]` input and button to the Manage Labels modal footer
- Validates input: rejects empty names, duplicates, and reserved `"project"` type
- Categories auto-uppercase; types auto-lowercase
- Placeholder updates when switching between Types/Categories tabs
- New labels appear immediately in dropdowns/filters

## Fixes
- Removed excessive scroll space (300vh pseudo-element on column dividers was leaking into modal)
- Removed button height mismatch (input and Create button now match Done button height)
- Fixed background page scroll bleed when modal is open (MutationObserver watches modals and locks body)

## Test plan
- [ ] Open admin → Manage Labels → Types tab: create a new type (e.g., "workshop") → appears in list and type dropdowns
- [ ] Try creating `project` → shows "Reserved name."
- [ ] Try duplicate → shows "Already exists."
- [ ] Switch to Categories tab: create category → auto-uppercased, appears in category dropdowns
- [ ] Scroll modal past boundary → background page doesn't scroll
- [ ] Modal has no excess scroll space below entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)