### PR TITLE
Fix admin body field being lost on save

### DIFF
--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -626,7 +626,10 @@
       change.collaborators = e.collaborators;
       change.relatedProjects = e.relatedProjects;
       change.relatedEntries = e.relatedEntries;
-      change.body = e.body;
+      var orig = originals[e.filePath];
+      if (!orig || e.body !== orig.body) {
+        change.body = e.body;
+      }
 
       changes[e.filePath] = change;
     });

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -579,7 +579,7 @@ eleventyExcludeFromCollections: true
         active: {{ (entry.data.active if entry.data.active is defined else true) | dump | safe }},
         collaborators: {{ (entry.data.collaborators or []) | dump | safe }},
         relatedProjects: {{ (entry.data.relatedProjects or []) | dump | safe }},
-        body: {{ (entry.rawInput | markdownBody or "") | dump | safe }},
+        body: {{ (entry.rawInput or "") | trim | dump | safe }},
         filePath: {{ entry.inputPath | replace("./", "") | dump | safe }}
       },
       {%- endfor %}

--- a/netlify/functions/update-entries.mjs
+++ b/netlify/functions/update-entries.mjs
@@ -104,8 +104,11 @@ function applyChangesToFile(fileContent, change) {
   if (change.relatedEntries !== undefined)    d.relatedEntries = change.relatedEntries;
   if (change.active !== undefined)            d.active = change.active;
 
-  // Body text replaces markdown content (below frontmatter)
-  const bodyContent = change.body !== undefined ? (change.body || '') : parsed.content;
+  // Body text replaces markdown content (below frontmatter).
+  // Only replace when the caller explicitly provides a non-empty body; otherwise preserve existing content.
+  const bodyContent = (change.body !== undefined && change.body !== null && change.body !== '')
+    ? change.body
+    : parsed.content;
 
   // Remove null/undefined fields to keep files clean
   Object.keys(d).forEach(key => { if (d[key] === null || d[key] === undefined) delete d[key]; });


### PR DESCRIPTION
## Summary

- **Client-side** ([`admin.js`](_includes/assets/js/admin.js)): `change.body` is now only included in the change payload when the body has actually changed from the original snapshot. Previously it was always sent, even when untouched.
- **Server-side** ([`update-entries.mjs`](netlify/functions/update-entries.mjs)): `applyChangesToFile()` now treats `undefined`, `null`, or `""` as "no body change" and preserves the existing file content. Previously, any falsy value from the client (including an empty string) would overwrite the file's body with nothing.

## Test plan

- [ ] Open an entry with body content (e.g. `Pool Pavilion`) in the admin panel — confirm the Body field shows the existing text
- [ ] Edit only a frontmatter field, click Apply Changes, then Save — confirm the committed file still has its original body content
- [ ] Edit the body text, save — confirm the new body content is saved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)