### PR TITLE
Fix admin file uploads never being committed to repo

### DIFF
--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -643,6 +643,10 @@
     }
 
     var count = Object.keys(changes).length;
+    Object.keys(fileOps).forEach(function(path) {
+      if (changes[path]) return;
+      if (buildFileOpsList(path, fileOps[path]).length > 0) count++;
+    });
     changeCountEl.hidden = count === 0;
     changeCountEl.textContent = count + ' change' + (count === 1 ? '' : 's');
     saveBtn.disabled = count === 0;
@@ -3074,6 +3078,21 @@
       });
     });
 
+    Object.keys(fileOps).forEach(function(path) {
+      if (changes[path]) return;
+      var opsList = buildFileOpsList(path, fileOps[path]);
+      if (opsList.length === 0) return;
+      var entry = entries.filter(function(e) { return e.filePath === path; })[0];
+      var entryName = entry ? (entry.title || entry.slug || path) : path;
+      html += '<tr class="sct-entry-first sct-entry-last">';
+      html += '<td class="sct-col-entry">' + esc(entryName) + '</td>';
+      html += '<td class="sct-col-action"><span class="sct-action">Edit</span></td>';
+      html += '<td class="sct-col-field">Files</td>';
+      html += '<td class="sct-col-old">—</td>';
+      html += '<td class="sct-col-new">' + opsList.length + ' file operation(s)</td>';
+      html += '</tr>';
+    });
+
     return html;
   }
 
@@ -3329,8 +3348,11 @@
   // ---- Save ----
   saveBtn.addEventListener('click', function() {
     syncRelatedEntries();
+    var hasPendingFileOps = Object.keys(fileOps).some(function(path) {
+      return buildFileOpsList(path, fileOps[path]).length > 0;
+    });
     var changeList = Object.keys(changes).map(function(path) { return changes[path]; });
-    if (changeList.length === 0) return;
+    if (changeList.length === 0 && !hasPendingFileOps) return;
     saveConfirmTbody.innerHTML = buildSaveConfirmRows();
     saveConfirmModal.hidden = false;
   });

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -1348,6 +1348,7 @@
       var ext = getExtension(file.name);
       var defaultName = file.name.replace(/\.[^.]+$/, '');
       ensureFileOps(activeEditPath);
+      syncFileNamesFromRows(epFilesGalleryList, fileOps[activeEditPath].gallery);
       fileOps[activeEditPath].gallery.push({
         status: 'upload', base64: base64, mimeType: mimeType,
         displayName: defaultName, path: '', origPath: null,
@@ -1369,6 +1370,7 @@
       var ext = getExtension(file.name);
       var defaultName = file.name.replace(/\.[^.]+$/, '');
       ensureFileOps(activeEditPath);
+      syncFileNamesFromRows(epFilesDrawingsList, fileOps[activeEditPath].drawings);
       fileOps[activeEditPath].drawings.push({
         status: 'upload', base64: base64, mimeType: mimeType,
         displayName: defaultName, path: '', origPath: null,
@@ -1390,6 +1392,7 @@
       var ext = getExtension(file.name);
       var defaultName = file.name.replace(/\.[^.]+$/, '');
       ensureFileOps(activeEditPath);
+      syncFileNamesFromRows(epFilesToolkitList, fileOps[activeEditPath].toolkit);
       fileOps[activeEditPath].toolkit.push({
         status: 'upload', base64: base64, mimeType: mimeType,
         displayName: defaultName, path: '', origPath: null,


### PR DESCRIPTION
## Summary

- The save button handler returned early when `changes{}` was empty, but file operations live in the separate `fileOps{}` object — so uploading files without also editing frontmatter silently did nothing
- `updateChanges()`: now counts entries with pending file ops toward the change badge, so the save button enables correctly
- Save button handler: checks for pending `fileOps` before returning, so the confirm modal opens even when only files have changed
- `buildSaveConfirmRows()`: shows file-op-only entries in the confirm table so users can see what will be committed

`doSave()` and the Netlify function were already handling file ops correctly — the bug was entirely in the gate before they were reached.

## Test plan

- [ ] Open a project entry, upload an image in the Files section, click Apply Changes — save button should enable and change counter should increment
- [ ] Click Save — confirm modal should list the entry with "file operation(s)"
- [ ] Confirm save — image should appear in the GitHub repo under the entry folder
- [ ] Also test editing frontmatter AND uploading a file — both should appear in the confirm modal and commit together

🤖 Generated with [Claude Code](https://claude.com/claude-code)