### PR TITLE
Fix drag-to-reorder files not enabling save

### DIFF
--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -1220,6 +1220,7 @@
         var moved = items.splice(fromIdx, 1)[0];
         items.splice(toIdx, 0, moved);
         renderFilesList(listEl, items);
+        updateChanges();
       });
     });
   }


### PR DESCRIPTION
## Summary

- After a drag-drop reorder in the Files section, `updateChanges()` was never called
- The pending file ops weren't counted toward the change badge, so the save button stayed disabled and the modal never opened
- `buildFileOpsList` was already generating the correct rename ops (based on changed numeric prefixes) — the only missing piece was triggering `updateChanges()` after each drop

One line added at the end of the `drop` event handler in `renderFilesList`.

## Test plan

- [ ] Open a project entry with multiple gallery images
- [ ] Drag to reorder them — save button should enable and change counter should increment
- [ ] Save — images should appear in the repo with updated numeric prefixes reflecting the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)