### PR TITLE
Replace numeric ADU build costs with qualitative tiers; add bathrooms field

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -393,31 +393,11 @@ eleventyConfig.addAsyncShortcode("generateImage", async function(params) {
     return "$" + Math.round(n / 1000) + "K";
   });
 
-  // Format an ADU object's budget as "$LOW–$HIGH" (e.g. "$65K–$95K")
+  // Return an ADU object's qualitative cost tier as an uppercase word.
+  // Filter name retained (was "aduPriceRange") to minimize churn at call sites.
   eleventyConfig.addFilter("aduPriceRange", function(adu) {
-    if (!adu || typeof adu.budget_low !== "number" || typeof adu.budget_high !== "number") return "";
-    return "$" + Math.round(adu.budget_low / 1000) + "K–$" + Math.round(adu.budget_high / 1000) + "K";
-  });
-
-  // Bucket key for budget filtering ("under-100k", "100k-150k", etc.)
-  eleventyConfig.addFilter("aduBudgetBucket", function(adu) {
-    if (!adu || typeof adu.budget_low !== "number") return "";
-    const mid = (adu.budget_low + adu.budget_high) / 2;
-    if (mid < 100000) return "under-100k";
-    if (mid < 150000) return "100k-150k";
-    if (mid < 200000) return "150k-200k";
-    return "over-200k";
-  });
-
-  // Minimum budget_low across a list of ADU projects, formatted "$62K".
-  // Used by the tier header to show "Starts at $XK".
-  eleventyConfig.addFilter("aduTierMinPrice", function(projects) {
-    if (!Array.isArray(projects) || projects.length === 0) return "";
-    const lows = projects
-      .map(p => p.data && p.data.adu && p.data.adu.budget_low)
-      .filter(n => typeof n === "number");
-    if (lows.length === 0) return "";
-    return "$" + Math.round(Math.min(...lows) / 1000) + "K";
+    if (!adu || !adu.cost_tier) return "";
+    return String(adu.cost_tier).toUpperCase();
   });
 
   // Filter an aduLibrary collection to just one tier.

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -198,13 +198,15 @@
   var epAduTierLabel = document.getElementById('ep-adu-tier-label');
   var epAduTierDrawer = document.getElementById('ep-adu-tier-drawer');
   var epAduBedrooms = document.getElementById('ep-adu-bedrooms');
+  var epAduBathrooms = document.getElementById('ep-adu-bathrooms');
   var epAduLoft = document.getElementById('ep-adu-loft');
   var epAduStairDropdown = document.getElementById('ep-adu-stair-dropdown');
   var epAduStairLabel = document.getElementById('ep-adu-stair-label');
   var epAduStairDrawer = document.getElementById('ep-adu-stair-drawer');
   var epAduSqft = document.getElementById('ep-adu-sqft');
-  var epAduBudgetLow = document.getElementById('ep-adu-budget-low');
-  var epAduBudgetHigh = document.getElementById('ep-adu-budget-high');
+  var epAduCostTierDropdown = document.getElementById('ep-adu-cost-tier-dropdown');
+  var epAduCostTierLabel = document.getElementById('ep-adu-cost-tier-label');
+  var epAduCostTierDrawer = document.getElementById('ep-adu-cost-tier-drawer');
   var epAduOrientationDropdown = document.getElementById('ep-adu-orientation-dropdown');
   var epAduOrientationLabel = document.getElementById('ep-adu-orientation-label');
   var epAduOrientationDrawer = document.getElementById('ep-adu-orientation-drawer');
@@ -217,6 +219,7 @@
 
   // Local state for the ADU sub-panel while the panel is open
   var epAduTierValue = '';
+  var epAduCostTierValue = '';
   var epAduStairValue = '';
   var epAduOrientationValue = '';
   var epAduFeaturesValue = [];
@@ -586,9 +589,25 @@
   // Show/hide ADU spec sub-fields. They appear only when:
   //   1. The entry is a project (so .project-only block is visible at all), AND
   //   2. The "ADU library" checkbox is on
+  // When ADU library is on, also hide .project-only-not-adu rows (Year, Location,
+  // Status) since the ADU header swap replaces them with Tier / Bed-Bath / Sqft.
   function updateAduVisibility() {
     var show = !!(epAduLibrary && epAduLibrary.checked);
     document.querySelectorAll('.adu-only').forEach(function(el) { el.hidden = !show; });
+    // Re-evaluate Year/Location/Status: hidden when ADU is on; visible when ADU is
+    // off AND the parent .project-only group is currently visible (entry is a project).
+    document.querySelectorAll('.project-only-not-adu').forEach(function(el) {
+      if (show) {
+        el.hidden = true;
+      } else {
+        // .project-only-not-adu always also carries .project-only; mirror its visibility.
+        // If the project-only group is hidden (non-project entry), keep hidden.
+        // Detect by checking another pure .project-only element that lacks the -not-adu class.
+        var projOnlyRef = document.querySelector('.project-only:not(.project-only-not-adu)');
+        var projVisible = projOnlyRef ? !projOnlyRef.hidden : true;
+        el.hidden = !projVisible;
+      }
+    });
   }
 
   function toDateInputValue(dateVal) {
@@ -2306,12 +2325,19 @@
     none: 'Single-story (none)'
   };
   var ADU_ORIENTATION_LABELS = { any: 'Any', 'north-south': 'North–South', 'east-west': 'East–West' };
+  var ADU_COST_TIER_LABELS = { low: 'Low', medium: 'Medium', high: 'High' };
 
   bindAduSelectDropdown(
     epAduTierDropdown, epAduTierDrawer, epAduTierLabel,
     function(v) { epAduTierValue = v; },
     function() { return epAduTierValue; },
     ADU_TIER_LABELS
+  );
+  bindAduSelectDropdown(
+    epAduCostTierDropdown, epAduCostTierDrawer, epAduCostTierLabel,
+    function(v) { epAduCostTierValue = v; },
+    function() { return epAduCostTierValue; },
+    ADU_COST_TIER_LABELS
   );
   bindAduSelectDropdown(
     epAduStairDropdown, epAduStairDrawer, epAduStairLabel,
@@ -2391,11 +2417,11 @@
     var obj = {};
     if (epAduTierValue) obj.tier = epAduTierValue;
     if (epAduBedrooms.value !== '')                      obj.bedrooms = Number(epAduBedrooms.value);
+    if (epAduBathrooms && epAduBathrooms.value !== '')   obj.bathrooms = Number(epAduBathrooms.value);
     if (epAduLoft.checked)                               obj.loft = true;
     if (epAduStairValue) obj.stair = epAduStairValue;
     if (epAduSqft.value !== '')                          obj.sqft = Number(epAduSqft.value);
-    if (epAduBudgetLow.value !== '')                     obj.budget_low = Number(epAduBudgetLow.value);
-    if (epAduBudgetHigh.value !== '')                    obj.budget_high = Number(epAduBudgetHigh.value);
+    if (epAduCostTierValue) obj.cost_tier = epAduCostTierValue;
     if (epAduOrientationValue) obj.orientation = epAduOrientationValue;
     if (epAduFootprint.value.trim())                     obj.footprint = epAduFootprint.value.trim();
     if (epAduHeight.value.trim())                        obj.height = epAduHeight.value.trim();
@@ -2415,10 +2441,11 @@
     setAduSelectFromValue(epAduStairDrawer, epAduStairLabel, epAduStairValue, ADU_STAIR_LABELS);
     setAduSelectFromValue(epAduOrientationDrawer, epAduOrientationLabel, epAduOrientationValue, ADU_ORIENTATION_LABELS);
     if (epAduBedrooms)    epAduBedrooms.value = adu.bedrooms != null ? adu.bedrooms : '';
+    if (epAduBathrooms)   epAduBathrooms.value = adu.bathrooms != null ? adu.bathrooms : '';
     if (epAduLoft)        epAduLoft.checked = !!adu.loft;
     if (epAduSqft)        epAduSqft.value = adu.sqft != null ? adu.sqft : '';
-    if (epAduBudgetLow)   epAduBudgetLow.value = adu.budget_low != null ? adu.budget_low : '';
-    if (epAduBudgetHigh)  epAduBudgetHigh.value = adu.budget_high != null ? adu.budget_high : '';
+    epAduCostTierValue = adu.cost_tier || '';
+    setAduSelectFromValue(epAduCostTierDrawer, epAduCostTierLabel, epAduCostTierValue, ADU_COST_TIER_LABELS);
     if (epAduFootprint)   epAduFootprint.value = adu.footprint || '';
     if (epAduHeight)      epAduHeight.value = adu.height || '';
     renderAduFeatureTags();

--- a/_includes/components/aduCompareTray.njk
+++ b/_includes/components/aduCompareTray.njk
@@ -309,11 +309,11 @@
 
   const ATTRS = [
     { key: "tier",        label: "TIER" },
-    { key: "bedrooms",    label: "BEDROOMS" },
+    { key: "bedrooms",    label: "BED/BATH" },
     { key: "stair",       label: "STAIR" },
     { key: "footprint",   label: "FOOTPRINT" },
     { key: "sqft",        label: "SQFT" },
-    { key: "price",       label: "BUILD COST" },
+    { key: "price",       label: "COST TIER" },
     { key: "orientation", label: "ORIENTATION" },
     { key: "height",      label: "HEIGHT" },
     { key: "features",    label: "FEATURES" }

--- a/_includes/components/aduMatchQuiz.njk
+++ b/_includes/components/aduMatchQuiz.njk
@@ -245,15 +245,14 @@
   </div>
 
   <div class="adu-match-quiz__body" id="adu-match-body">
-    {# STEP 0: Budget #}
+    {# STEP 0: Cost tier #}
     <section class="adu-match-quiz__step is-active" data-step="0">
       <h2 class="adu-match-quiz__step-title">01 · WHAT'S YOUR CONSTRUCTION BUDGET?</h2>
-      <p class="adu-match-quiz__step-hint">Estimated all-in build cost (materials + labor). Pick the range closest to your number.</p>
+      <p class="adu-match-quiz__step-hint">Build cost varies by location, year, and builder, so we use qualitative tiers. Pick the level that best matches your means.</p>
       <div class="adu-match-quiz__chips">
-        <button class="adu-match-quiz__chip" type="button" data-field="budget" data-value="under-100k">&lt; $100K</button>
-        <button class="adu-match-quiz__chip" type="button" data-field="budget" data-value="100k-150k">$100–150K</button>
-        <button class="adu-match-quiz__chip" type="button" data-field="budget" data-value="150k-200k">$150–200K</button>
-        <button class="adu-match-quiz__chip" type="button" data-field="budget" data-value="over-200k">&gt; $200K</button>
+        <button class="adu-match-quiz__chip" type="button" data-field="cost_tier" data-value="low">LOW</button>
+        <button class="adu-match-quiz__chip" type="button" data-field="cost_tier" data-value="medium">MEDIUM</button>
+        <button class="adu-match-quiz__chip" type="button" data-field="cost_tier" data-value="high">HIGH</button>
       </div>
     </section>
 
@@ -315,18 +314,12 @@
 <script>
 (function () {
   const STORAGE_KEY = "lowdo-adu-match";
-  const BUDGET_MIDPOINT = {
-    "under-100k": 80000,
-    "100k-150k": 125000,
-    "150k-200k": 175000,
-    "over-200k": 230000
+  const COST_TIER_LABEL = {
+    "low": "LOW",
+    "medium": "MEDIUM",
+    "high": "HIGH"
   };
-  const BUDGET_LABEL = {
-    "under-100k": "< $100K",
-    "100k-150k": "$100–150K",
-    "150k-200k": "$150–200K",
-    "over-200k": "> $200K"
-  };
+  const COST_TIER_RANK = { "low": 0, "medium": 1, "high": 2 };
   const BEDROOMS_LABEL = {
     "1": "1 BR",
     "1+loft": "1 BR + LOFT",
@@ -353,7 +346,7 @@
   const clearBtn= document.getElementById("adu-match-clear");
   const results = document.getElementById("adu-match-results");
 
-  const defaultState = () => ({ active: false, step: 0, budget: null, bedrooms: null, orientation: null, prefs: [] });
+  const defaultState = () => ({ active: false, step: 0, cost_tier: null, bedrooms: null, orientation: null, prefs: [] });
   const load = () => { try { return JSON.parse(sessionStorage.getItem(STORAGE_KEY) || "null") || defaultState(); } catch (e) { return defaultState(); } };
   const save = (s) => sessionStorage.setItem(STORAGE_KEY, JSON.stringify(s));
   const esc  = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
@@ -375,7 +368,7 @@
   }
 
   function canAdvance() {
-    if (state.step === 0) return state.budget != null;
+    if (state.step === 0) return state.cost_tier != null;
     if (state.step === 1) return state.bedrooms != null;
     if (state.step === 2) return state.orientation != null;
     if (state.step === 3) return true; // prefs is optional
@@ -436,19 +429,20 @@
 
   trigger.addEventListener("click", () => openQuiz(0));
 
-  // Scoring — ported from mockups/a-configurator.html scoreAdu().
+  // Scoring — tier-distance for cost; exact-or-near for other fields.
   function scoreRow(row) {
     const ds = row.dataset;
-    const budgetMid = BUDGET_MIDPOINT[state.budget] || 0;
-    const lo = parseInt(ds.budgetLow, 10) || 0;
-    const hi = parseInt(ds.budgetHigh, 10) || 0;
-    const median = (lo + hi) / 2;
     let score = 0;
 
-    if (budgetMid >= lo && budgetMid <= hi)       score += 30;
-    else if (budgetMid > hi)                      score += 22;
-    else if (budgetMid >= median * 0.85)          score += 10;
-    else                                          score -= 10;
+    // Cost tier: exact match wins big; adjacent gets a small bonus; far gets nothing.
+    // Entries missing cost_tier score 0 (no penalty).
+    const pickRank = COST_TIER_RANK[state.cost_tier];
+    const rowRank  = COST_TIER_RANK[ds.costTier];
+    if (pickRank != null && rowRank != null) {
+      const dist = Math.abs(pickRank - rowRank);
+      if (dist === 0)      score += 30;
+      else if (dist === 1) score += 10;
+    }
 
     const beds = parseInt(ds.bedrooms, 10);
     const loft = ds.loft === "true";
@@ -489,7 +483,7 @@
 
   function summaryText() {
     const parts = [];
-    if (state.budget)       parts.push(BUDGET_LABEL[state.budget]);
+    if (state.cost_tier)    parts.push(COST_TIER_LABEL[state.cost_tier]);
     if (state.bedrooms)     parts.push(BEDROOMS_LABEL[state.bedrooms]);
     if (state.orientation && state.orientation !== "any") parts.push(ORIENTATION_LABEL[state.orientation]);
     if (state.prefs.length) parts.push("+" + state.prefs.length + " MUST-HAVE" + (state.prefs.length === 1 ? "" : "S"));
@@ -549,7 +543,7 @@
   });
 
   // On boot, if a previous session left the quiz active, replay submit().
-  if (state.active && state.budget) {
+  if (state.active && state.cost_tier) {
     // Re-run submit() to rebuild the flat list. We bypass clearFilters here
     // because no filters can be active on a fresh load.
     document.body.classList.add("is-matching");

--- a/_includes/components/aduTierHeader.njk
+++ b/_includes/components/aduTierHeader.njk
@@ -8,8 +8,4 @@
     <div class="adu-tier-header__name">{{ tier.name | upper }}</div>
   </div>
   <div class="adu-tier-header__pitch-cell">{{ tier.pitch }}</div>
-  <div class="adu-tier-header__price-cell">
-    <span class="adu-tier-header__price-label">STARTS AT</span>
-    <span class="adu-tier-header__price-amount">{{ tierProjects | aduTierMinPrice }} <small>BUILD COST</small></span>
-  </div>
 </section>

--- a/_includes/layouts/project.njk
+++ b/_includes/layouts/project.njk
@@ -1180,26 +1180,48 @@ section: project
           </div>
         </div>
 
-        {# Bottom section: Location, year, status #}
+        {# Bottom section: header metadata
+           - ADU library entries: Tier, Bed/Bath, Square footage (from `adu` object)
+           - Other projects: Location, Year, Status #}
         <div class="project-meta-bottom">
-          {# Rows: Label (col 3) + Value (col 4) #}
-          {% if location %}
-            <div class="project-meta-row">
-              <div class="project-meta-label">Location</div>
-              <div class="project-meta-value">{{ location }}</div>
-            </div>
-          {% endif %}
-          {% if year and settings.theme.theme_features.show_project_year %}
-            <div class="project-meta-row">
-              <div class="project-meta-label">Year</div>
-              <div class="project-meta-value">{{ year }}</div>
-            </div>
-          {% endif %}
-          {% if status %}
-            <div class="project-meta-row">
-              <div class="project-meta-label">Status</div>
-              <div class="project-meta-value">{{ status }}</div>
-            </div>
+          {% if adu_library and adu %}
+            {% if adu.tier %}
+              <div class="project-meta-row">
+                <div class="project-meta-label">Tier</div>
+                <div class="project-meta-value">{{ adu.tier | upper }}</div>
+              </div>
+            {% endif %}
+            {% if adu.bedrooms != null %}
+              <div class="project-meta-row">
+                <div class="project-meta-label">Bed / Bath</div>
+                <div class="project-meta-value">{{ adu.bedrooms }} BR / {{ adu.bathrooms or 1 }} BA{% if adu.loft %} + LOFT{% endif %}</div>
+              </div>
+            {% endif %}
+            {% if adu.sqft %}
+              <div class="project-meta-row">
+                <div class="project-meta-label">Square footage</div>
+                <div class="project-meta-value">{{ adu.sqft }} SQFT</div>
+              </div>
+            {% endif %}
+          {% else %}
+            {% if location %}
+              <div class="project-meta-row">
+                <div class="project-meta-label">Location</div>
+                <div class="project-meta-value">{{ location }}</div>
+              </div>
+            {% endif %}
+            {% if year and settings.theme.theme_features.show_project_year %}
+              <div class="project-meta-row">
+                <div class="project-meta-label">Year</div>
+                <div class="project-meta-value">{{ year }}</div>
+              </div>
+            {% endif %}
+            {% if status %}
+              <div class="project-meta-row">
+                <div class="project-meta-label">Status</div>
+                <div class="project-meta-value">{{ status }}</div>
+              </div>
+            {% endif %}
           {% endif %}
         </div>
 
@@ -1226,8 +1248,8 @@ section: project
       <div class="project-specs-row">
         <div class="project-specs-cell project-specs-cell--label">Tier</div>
         <div class="project-specs-cell">{{ adu.tier | upper }}</div>
-        <div class="project-specs-cell project-specs-cell--label">Bedrooms</div>
-        <div class="project-specs-cell">{{ adu.bedrooms }}{% if adu.loft %} + LOFT{% endif %}</div>
+        <div class="project-specs-cell project-specs-cell--label">Bed / Bath</div>
+        <div class="project-specs-cell">{{ adu.bedrooms }} BR / {{ adu.bathrooms or 1 }} BA{% if adu.loft %} + LOFT{% endif %}</div>
       </div>
 
       <div class="project-specs-row">
@@ -1247,7 +1269,7 @@ section: project
       <div class="project-specs-row">
         <div class="project-specs-cell project-specs-cell--label">Orientation</div>
         <div class="project-specs-cell">{% if adu.orientation == "any" %}ANY LOT{% else %}{{ adu.orientation | upper }}{% endif %}</div>
-        <div class="project-specs-cell project-specs-cell--label">Build cost (est.)</div>
+        <div class="project-specs-cell project-specs-cell--label">Cost tier</div>
         <div class="project-specs-cell">{{ adu | aduPriceRange }}</div>
       </div>
 

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -234,16 +234,16 @@ eleventyExcludeFromCollections: true
             <div class="ep-row__control">
               <input type="date" id="ep-date">
             </div>
-            <span class="ep-row__label project-only" data-tooltip="Displayed in the project header on the detail page (e.g. '2022–Present').">Year</span>
-            <div class="ep-row__control project-only">
+            <span class="ep-row__label project-only project-only-not-adu" data-tooltip="Displayed in the project header on the detail page (e.g. '2022–Present'). Hidden for ADU library entries.">Year</span>
+            <div class="ep-row__control project-only project-only-not-adu">
               <input type="text" id="ep-year" placeholder="2024 or 2022–Present">
             </div>
-            <span class="ep-row__label project-only" data-tooltip="Shown in the project header metadata on the detail page.">Location</span>
-            <div class="ep-row__control project-only">
+            <span class="ep-row__label project-only project-only-not-adu" data-tooltip="Shown in the project header metadata on the detail page. Hidden for ADU library entries.">Location</span>
+            <div class="ep-row__control project-only project-only-not-adu">
               <input type="text" id="ep-location" placeholder="Austin, TX">
             </div>
-            <span class="ep-row__label project-only" data-tooltip="Shown in the project header metadata on the detail page (e.g. 'Built', 'In Progress').">Status</span>
-            <div class="ep-row__control project-only">
+            <span class="ep-row__label project-only project-only-not-adu" data-tooltip="Shown in the project header metadata on the detail page (e.g. 'Built', 'In Progress'). Hidden for ADU library entries.">Status</span>
+            <div class="ep-row__control project-only project-only-not-adu">
               <div class="tag-input-wrap">
                 <input type="text" id="ep-status" placeholder="Built / In Progress / Unbuilt" autocomplete="off">
                 <ul id="ep-status-suggestions" class="tag-suggestions" hidden></ul>
@@ -397,6 +397,11 @@ eleventyExcludeFromCollections: true
               <input type="number" id="ep-adu-bedrooms" min="0" step="1" placeholder="1">
             </div>
 
+            <span class="ep-row__label adu-only" data-tooltip="Number of full bathrooms. Use 0.5 increments for half-baths.">Bathrooms</span>
+            <div class="ep-row__control adu-only">
+              <input type="number" id="ep-adu-bathrooms" min="0" step="0.5" placeholder="1">
+            </div>
+
             <span class="ep-row__label adu-only" data-tooltip="Whether this design includes an additional sleeping loft above the main floor.">Loft</span>
             <div class="ep-row__control adu-only">
               <label class="field-label--inline">
@@ -429,14 +434,22 @@ eleventyExcludeFromCollections: true
               <input type="number" id="ep-adu-sqft" min="0" step="10" placeholder="380">
             </div>
 
-            <span class="ep-row__label adu-only" data-tooltip="Estimated low-end build cost (whole dollars). Shown on /adu-library/ and the project page as a range.">Build cost — low</span>
+            <span class="ep-row__label adu-only" data-tooltip="Qualitative build-cost tier. Shown on /adu-library/ and the project page as a single word (LOW/MEDIUM/HIGH).">Cost tier</span>
             <div class="ep-row__control adu-only">
-              <input type="number" id="ep-adu-budget-low" min="0" step="1000" placeholder="65000">
-            </div>
-
-            <span class="ep-row__label adu-only" data-tooltip="Estimated high-end build cost (whole dollars).">Build cost — high</span>
-            <div class="ep-row__control adu-only">
-              <input type="number" id="ep-adu-budget-high" min="0" step="1000" placeholder="95000">
+              <div class="admin-dropdown ep-adu-cost-tier-dropdown" id="ep-adu-cost-tier-dropdown">
+                <button class="admin-dropdown__button" aria-expanded="false" type="button">
+                  <span class="admin-dropdown__label" id="ep-adu-cost-tier-label">—</span>
+                  <svg class="admin-dropdown__chevron" width="8" height="5" viewBox="0 0 8 5" fill="none" aria-hidden="true">
+                    <path d="M1 1l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+                  </svg>
+                </button>
+                <div class="admin-dropdown__drawer" aria-hidden="true" id="ep-adu-cost-tier-drawer">
+                  <button class="admin-dropdown__item" type="button" data-value="">—</button>
+                  <button class="admin-dropdown__item" type="button" data-value="low">Low</button>
+                  <button class="admin-dropdown__item" type="button" data-value="medium">Medium</button>
+                  <button class="admin-dropdown__item" type="button" data-value="high">High</button>
+                </div>
+              </div>
             </div>
 
             <span class="ep-row__label adu-only" data-tooltip="Lot orientation the design works best on.">Orientation</span>

--- a/adu-library.njk
+++ b/adu-library.njk
@@ -524,12 +524,11 @@ section: adu-library
     </div>
 
     <div class="adu-filter-block">
-      <div class="adu-filter-block__heading">BUDGET</div>
+      <div class="adu-filter-block__heading">COST TIER</div>
       <div class="adu-filter-block__list">
-        <label class="index-filter"><input type="checkbox" data-filter="budget" data-value="under-100k"><span class="index-filter__box"></span><span class="index-filter__label">&lt; $100K</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="budget" data-value="100k-150k"><span class="index-filter__box"></span><span class="index-filter__label">$100–150K</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="budget" data-value="150k-200k"><span class="index-filter__box"></span><span class="index-filter__label">$150–200K</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="budget" data-value="over-200k"><span class="index-filter__box"></span><span class="index-filter__label">&gt; $200K</span></label>
+        <label class="index-filter"><input type="checkbox" data-filter="cost_tier" data-value="low"><span class="index-filter__box"></span><span class="index-filter__label">LOW</span></label>
+        <label class="index-filter"><input type="checkbox" data-filter="cost_tier" data-value="medium"><span class="index-filter__box"></span><span class="index-filter__label">MEDIUM</span></label>
+        <label class="index-filter"><input type="checkbox" data-filter="cost_tier" data-value="high"><span class="index-filter__box"></span><span class="index-filter__label">HIGH</span></label>
       </div>
     </div>
 
@@ -577,9 +576,7 @@ section: adu-library
                      data-bedrooms="{{ adu.bedrooms }}"
                      data-loft="{{ 'true' if adu.loft else 'false' }}"
                      data-stair="{{ adu.stair }}"
-                     data-budget="{{ adu | aduBudgetBucket }}"
-                     data-budget-low="{{ adu.budget_low }}"
-                     data-budget-high="{{ adu.budget_high }}"
+                     data-cost-tier="{{ adu.cost_tier }}"
                      data-orientation="{{ adu.orientation }}"
                      data-height="{{ adu.height }}"
                      data-features="{{ adu.features | join(',') if adu.features else '' }}">
@@ -622,14 +619,14 @@ section: adu-library
                     <div class="adu-row__spec-list">
                       <span><span class="adu-row__spec-label">FOOTPRINT</span> {{ adu.footprint | upper }}</span>
                       <span><span class="adu-row__spec-label">SQFT</span> {{ adu.sqft }}</span>
-                      <span><span class="adu-row__spec-label">BEDS</span> {{ adu.bedrooms }}{% if adu.loft %} + LOFT{% endif %}</span>
+                      <span><span class="adu-row__spec-label">BED/BATH</span> {{ adu.bedrooms }} BR / {{ adu.bathrooms or 1 }} BA{% if adu.loft %} + LOFT{% endif %}</span>
                       <span><span class="adu-row__spec-label">STAIR</span> {{ adu.stair | aduStairLabel | upper }}</span>
                     </div>
                   </div>
 
                   <div class="adu-row__cell adu-row__cell--price">
                     <span class="adu-row__price-range">{{ adu | aduPriceRange }}</span>
-                    <span class="adu-row__price-label">EST. BUILD COST</span>
+                    <span class="adu-row__price-label">COST TIER</span>
                     <span class="adu-row__view arrow--right">VIEW PROJECT</span>
                     <button class="adu-compare-btn"
                             type="button"
@@ -637,7 +634,7 @@ section: adu-library
                             data-compare-name="{{ project.data.title | upper }}"
                             data-compare-url="{{ project.url | url }}"
                             data-compare-tier="{{ adu.tier | upper }}"
-                            data-compare-bedrooms="{{ adu.bedrooms }}{% if adu.loft %} + LOFT{% endif %}"
+                            data-compare-bedrooms="{{ adu.bedrooms }} BR / {{ adu.bathrooms or 1 }} BA{% if adu.loft %} + LOFT{% endif %}"
                             data-compare-stair="{{ adu.stair | aduStairLabel | upper }}"
                             data-compare-footprint="{{ adu.footprint | upper }}"
                             data-compare-sqft="{{ adu.sqft }}"
@@ -699,13 +696,13 @@ section: adu-library
 (function () {
   var rows = Array.prototype.slice.call(document.querySelectorAll('.adu-row[data-adu]'));
   var countEl = document.getElementById('adu-result-count');
-  var filters = { bedrooms: [], loft: [], stair: [], budget: [], feature: [] };
+  var filters = { bedrooms: [], loft: [], stair: [], cost_tier: [], feature: [] };
 
   function rowMatches(row) {
     if (filters.bedrooms.length && filters.bedrooms.indexOf(row.dataset.bedrooms) < 0) return false;
     if (filters.loft.length && filters.loft.indexOf(row.dataset.loft) < 0) return false;
     if (filters.stair.length && filters.stair.indexOf(row.dataset.stair) < 0) return false;
-    if (filters.budget.length && filters.budget.indexOf(row.dataset.budget) < 0) return false;
+    if (filters.cost_tier.length && filters.cost_tier.indexOf(row.dataset.costTier) < 0) return false;
     if (filters.feature.length) {
       var rowFeats = (row.dataset.features || '').split(',').filter(Boolean);
       for (var i = 0; i < filters.feature.length; i++) {

--- a/entries/projects/adu-essential/adu-essential.md
+++ b/entries/projects/adu-essential/adu-essential.md
@@ -18,10 +18,11 @@ adu_library: true
 adu:
   tier: Essential
   bedrooms: 1
+  bathrooms: 1
   loft: true
   stair: ladder
   sqft: 592
-  budget_high: 95000
+  cost_tier: low
   orientation: north-south
   footprint: 21×33 ft
   height: single + loft

--- a/entries/projects/adu-gable-shade/adu-gable-shade.md
+++ b/entries/projects/adu-gable-shade/adu-gable-shade.md
@@ -14,11 +14,11 @@ adu_library: true
 adu:
   tier: Standard
   bedrooms: 1
+  bathrooms: 1
   loft: true
   stair: ladder
   sqft: 720
-  budget_low: 145000
-  budget_high: 195000
+  cost_tier: high
   orientation: any
   footprint: 28×26 ft
   height: two levels

--- a/entries/projects/adu-gable-stair-adaptive/adu-gable-stair-adaptive.md
+++ b/entries/projects/adu-gable-stair-adaptive/adu-gable-stair-adaptive.md
@@ -16,5 +16,6 @@ adu:
   tier: Plus
   bedrooms: 2
   stair: straight
+  cost_tier: medium
 ---
 

--- a/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
+++ b/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
@@ -7,5 +7,6 @@ categories: []
 adu_library: true
 adu:
   tier: Plus
+  cost_tier: medium
 ---
 

--- a/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
+++ b/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
@@ -8,6 +8,8 @@ adu_library: true
 adu:
   tier: Plus
   bedrooms: 2
+  bathrooms: 1
   stair: straight
+  cost_tier: medium
 ---
 

--- a/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
+++ b/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
@@ -8,6 +8,8 @@ adu_library: true
 adu:
   tier: Plus
   bedrooms: 2
+  bathrooms: 1
   stair: ladder
+  cost_tier: medium
 ---
 

--- a/entries/projects/adu-shed-bed/adu-shed-bed.md
+++ b/entries/projects/adu-shed-bed/adu-shed-bed.md
@@ -14,10 +14,10 @@ adu_library: true
 adu:
   tier: Standard
   bedrooms: 2
+  bathrooms: 1
   stair: ladder
   sqft: 671
-  budget_low: 92000
-  budget_high: 135000
+  cost_tier: medium
   orientation: north-south
   footprint: 21x33 ft
   height: two-story

--- a/entries/projects/adu-shell-stair-adaptive/adu-shell-stair-adaptive.md
+++ b/entries/projects/adu-shell-stair-adaptive/adu-shell-stair-adaptive.md
@@ -8,6 +8,8 @@ adu_library: true
 adu:
   tier: Plus
   bedrooms: 2
+  bathrooms: 1
   stair: straight
+  cost_tier: medium
 ---
 

--- a/entries/projects/adu-shell-wraparound-porch/adu-shell-wraparound-porch.md
+++ b/entries/projects/adu-shell-wraparound-porch/adu-shell-wraparound-porch.md
@@ -8,7 +8,9 @@ adu_library: true
 adu:
   tier: Standard
   bedrooms: 2
+  bathrooms: 1
   stair: ladder
+  cost_tier: medium
 position: 999
 featured: false
 showInAwardsTable: false


### PR DESCRIPTION
## Summary
- Replace numeric build-cost ranges ($92K–$195K) with qualitative tiers (Low/Medium/High) across all ADU displays
- Add bathrooms field to ADU entries; swap project page headers from Location/Year/Status to Tier/Bed–Bath/Sqft
- Update ADU library filters, compare drawer, match quiz, and admin form to use new tier system

## Changes
- **9 ADU markdown files**: Replace `budget_low`/`budget_high` with `cost_tier` field
- **.eleventy.js**: Rewrite `aduPriceRange` filter; delete `aduBudgetBucket` and `aduTierMinPrice`
- **aduTierHeader.njk**: Remove "STARTS AT $X K BUILD COST" price cell
- **project.njk**: Swap header fields and relabel spec to "Cost tier"
- **adu-library.njk**: Replace 4 budget checkboxes with 3 tier checkboxes; update row display and filter logic
- **aduCompareTray.njk**: Relabel column to "COST TIER"
- **aduMatchQuiz.njk**: Replace budget chips with tier chips; implement tier-distance scoring
- **admin/index.njk**: Replace numeric inputs with cost-tier dropdown
- **admin.js**: Wire save/load for new cost_tier field

## Test Plan
- [x] Build passes: `npm run build`
- [x] Dev server renders correctly: `npm run serve`
- [x] ADU entries show correct tier: adu-essential (LOW), adu-gable-shade (HIGH), adu-shed-bed (MEDIUM)
- [ ] Verify on /adu-library/: filter toggles work, rows display tier correctly
- [ ] Verify on /project/adu-*: Specifications panel shows "Cost tier: TIER_VALUE"
- [ ] Verify compare drawer shows correct tier values
- [ ] Verify match quiz scoring with different tier picks
- [ ] Verify admin form: cost-tier dropdown saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)