### PR TITLE
Add "For Past Clients" tier to ADU Library

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -185,7 +185,7 @@ eleventyConfig.addAsyncShortcode("generateImage", async function(params) {
   // ADU library collection — projects that opt in via `adu_library: true`.
   // Sorted by tier (Essential → Standard → Plus) then by sqft (smallest first).
   eleventyConfig.addCollection("aduLibrary", function(collectionApi) {
-    const tierOrder = { Essential: 1, Standard: 2, Plus: 3 };
+    const tierOrder = { Essential: 1, Standard: 2, Plus: 3, "For Past Clients": 4 };
     return collectionApi.getFilteredByGlob("entries/projects/**/*.md")
       .filter(project => project.data.draft !== true)
       .filter(project => project.data.adu_library === true)

--- a/_data/aduTiers.yaml
+++ b/_data/aduTiers.yaml
@@ -16,3 +16,7 @@
     Two enclosed bedrooms, full kitchens, and the most architectural ambition.
     For property owners building an ADU as a long-term rental,
     multi-generational housing, or a primary creative space.
+- name: For Past Clients
+  edition: ""
+  pitch: >-
+    [TODO: pitch text to be supplied by user]

--- a/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
+++ b/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
@@ -6,7 +6,7 @@ date: 2026-05-13T00:00:00.000Z
 categories: []
 adu_library: true
 adu:
-  tier: Plus
+  tier: "For Past Clients"
   cost_tier: medium
 ---
 

--- a/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
+++ b/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
@@ -6,7 +6,7 @@ date: 2026-05-13T00:00:00.000Z
 categories: []
 adu_library: true
 adu:
-  tier: Plus
+  tier: "For Past Clients"
   bedrooms: 2
   bathrooms: 1
   stair: straight


### PR DESCRIPTION
## Summary
- Adds a 4th tier, **For Past Clients**, to `/adu-library/`, rendered below Essential / Standard / Plus
- Moves `ADU_0501` (Mishpocha Woods 01) and `ADU_0502` (Mishpocha Woods 02) into the new tier
- Tier metadata in [`_data/aduTiers.yaml`](_data/aduTiers.yaml); sort order extended in [`.eleventy.js`](.eleventy.js)
- Edition label is intentionally empty for this tier; pitch text is a `[TODO]` placeholder pending copy from the team — easy to update later in `_data/aduTiers.yaml` or via the admin panel

## Test plan
- [ ] `npm run serve` and open `/adu-library/` — verify section order: Essential → Standard → Plus → For Past Clients
- [ ] Verify `ADU_0501` and `ADU_0502` appear under "For Past Clients" and no longer under Plus
- [ ] Verify the new tier header renders without an edition label and shows the placeholder pitch
- [ ] Replace placeholder pitch text with final copy before merging (or as a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)