### PR TITLE
Sort ADU library alphabetically within each tier

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -183,7 +183,7 @@ eleventyConfig.addAsyncShortcode("generateImage", async function(params) {
   });
 
   // ADU library collection — projects that opt in via `adu_library: true`.
-  // Sorted by tier (Essential → Standard → Plus) then by sqft (smallest first).
+  // Sorted by tier (Essential → Standard → Plus) then alphabetically by title.
   eleventyConfig.addCollection("aduLibrary", function(collectionApi) {
     const tierOrder = { Essential: 1, Standard: 2, Plus: 3, "For Past Clients": 4 };
     return collectionApi.getFilteredByGlob("entries/projects/**/*.md")
@@ -193,7 +193,7 @@ eleventyConfig.addAsyncShortcode("generateImage", async function(params) {
         const tierA = tierOrder[a.data.adu?.tier] || 99;
         const tierB = tierOrder[b.data.adu?.tier] || 99;
         if (tierA !== tierB) return tierA - tierB;
-        return (a.data.adu?.sqft || 0) - (b.data.adu?.sqft || 0);
+        return (a.data.title || "").localeCompare(b.data.title || "");
       });
   });
 


### PR DESCRIPTION
## Summary
- Change ADU library secondary sort from `sqft` (smallest first) to alphabetical by title within each tier
- Tier order (Essential → Standard → Plus → For Past Clients) is unchanged

## Test plan
- [ ] `npm run serve` and visit `/adu-library/` — confirm entries within each tier section are now alphabetical by name