### PR TITLE
Consolidate ADU stair filter to Ladder-Int / Full-Int / Full-Ext

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -409,11 +409,9 @@ eleventyConfig.addAsyncShortcode("generateImage", async function(params) {
   // Human-readable stair label
   eleventyConfig.addFilter("aduStairLabel", function(stair) {
     return ({
-      "ladder":     "Ladder",
-      "spiral":     "Spiral stair",
-      "straight":   "Straight stair",
-      "switchback": "Switchback stair",
-      "none":       "Single-story"
+      "ladder-int": "Ladder-Int",
+      "full-int":   "Full-Int",
+      "full-ext":   "Full-Ext"
     })[stair] || stair || "";
   });
 

--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -2370,11 +2370,9 @@
 
   var ADU_TIER_LABELS = { Essential: 'Essential', Standard: 'Standard', Plus: 'Plus' };
   var ADU_STAIR_LABELS = {
-    ladder: 'Ladder',
-    spiral: 'Spiral stair',
-    straight: 'Straight stair',
-    switchback: 'Switchback stair',
-    none: 'Single-story (none)'
+    'ladder-int': 'Ladder-Int',
+    'full-int': 'Full-Int',
+    'full-ext': 'Full-Ext'
   };
   var ADU_ORIENTATION_LABELS = { any: 'Any', 'north-south': 'North–South', 'east-west': 'East–West' };
   var ADU_COST_TIER_LABELS = { low: 'Low', medium: 'Medium', high: 'High' };

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -409,7 +409,7 @@ eleventyExcludeFromCollections: true
               </label>
             </div>
 
-            <span class="ep-row__label adu-only" data-tooltip="Type of vertical circulation. 'Single-story' means no stair at all.">Stair</span>
+            <span class="ep-row__label adu-only" data-tooltip="Type of vertical circulation.">Stair</span>
             <div class="ep-row__control adu-only">
               <div class="admin-dropdown ep-adu-stair-dropdown" id="ep-adu-stair-dropdown">
                 <button class="admin-dropdown__button" aria-expanded="false" type="button">
@@ -420,11 +420,9 @@ eleventyExcludeFromCollections: true
                 </button>
                 <div class="admin-dropdown__drawer" aria-hidden="true" id="ep-adu-stair-drawer">
                   <button class="admin-dropdown__item" type="button" data-value="">—</button>
-                  <button class="admin-dropdown__item" type="button" data-value="ladder">Ladder</button>
-                  <button class="admin-dropdown__item" type="button" data-value="spiral">Spiral stair</button>
-                  <button class="admin-dropdown__item" type="button" data-value="straight">Straight stair</button>
-                  <button class="admin-dropdown__item" type="button" data-value="switchback">Switchback stair</button>
-                  <button class="admin-dropdown__item" type="button" data-value="none">Single-story (none)</button>
+                  <button class="admin-dropdown__item" type="button" data-value="ladder-int">Ladder-Int</button>
+                  <button class="admin-dropdown__item" type="button" data-value="full-int">Full-Int</button>
+                  <button class="admin-dropdown__item" type="button" data-value="full-ext">Full-Ext</button>
                 </div>
               </div>
             </div>

--- a/adu-library.njk
+++ b/adu-library.njk
@@ -515,11 +515,9 @@ section: adu-library
     <div class="adu-filter-block">
       <div class="adu-filter-block__heading">STAIR</div>
       <div class="adu-filter-block__list">
-        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="ladder"><span class="index-filter__box"></span><span class="index-filter__label">LADDER</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="spiral"><span class="index-filter__box"></span><span class="index-filter__label">SPIRAL</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="straight"><span class="index-filter__box"></span><span class="index-filter__label">STRAIGHT</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="switchback"><span class="index-filter__box"></span><span class="index-filter__label">SWITCHBACK</span></label>
-        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="none"><span class="index-filter__box"></span><span class="index-filter__label">SINGLE-STORY</span></label>
+        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="ladder-int"><span class="index-filter__box"></span><span class="index-filter__label">LADDER-INT</span></label>
+        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="full-int"><span class="index-filter__box"></span><span class="index-filter__label">FULL-INT</span></label>
+        <label class="index-filter"><input type="checkbox" data-filter="stair" data-value="full-ext"><span class="index-filter__box"></span><span class="index-filter__label">FULL-EXT</span></label>
       </div>
     </div>
 

--- a/entries/projects/adu-gable-shade/adu-gable-shade.md
+++ b/entries/projects/adu-gable-shade/adu-gable-shade.md
@@ -16,7 +16,7 @@ adu:
   bedrooms: 1
   bathrooms: 1
   loft: true
-  stair: ladder
+  stair: ladder-int
   sqft: 592
   cost_tier: low
   orientation: any

--- a/entries/projects/adu-gable-stair-adaptive/adu-gable-stair-adaptive.md
+++ b/entries/projects/adu-gable-stair-adaptive/adu-gable-stair-adaptive.md
@@ -17,7 +17,7 @@ active: true
 adu:
   tier: Plus
   bedrooms: 2
-  stair: straight
+  stair: full-int
   sqft: 591
   cost_tier: high
   orientation: any

--- a/entries/projects/adu-gable/adu-gable.md
+++ b/entries/projects/adu-gable/adu-gable.md
@@ -19,7 +19,7 @@ adu:
   bedrooms: 1
   bathrooms: 1
   loft: true
-  stair: ladder
+  stair: ladder-int
   sqft: 592
   cost_tier: low
   orientation: any

--- a/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
+++ b/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
@@ -10,6 +10,7 @@ adu_library: true
 adu:
   tier: "For Past Clients"
   cost_tier: medium
+  stair: full-ext
 position: 999
 featured: false
 showInAwardsTable: false

--- a/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
+++ b/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
@@ -11,7 +11,7 @@ adu:
   tier: "For Past Clients"
   bedrooms: 2
   bathrooms: 1
-  stair: straight
+  stair: full-int
   cost_tier: medium
 position: 999
 featured: false

--- a/entries/projects/adu-monitor-stair-adaptive/adu-monitor-stair-adaptive.md
+++ b/entries/projects/adu-monitor-stair-adaptive/adu-monitor-stair-adaptive.md
@@ -11,7 +11,7 @@ adu:
   tier: Plus
   bedrooms: 2
   bathrooms: 1
-  stair: straight
+  stair: full-int
   cost_tier: high
   orientation: any
 position: 999

--- a/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
+++ b/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
@@ -11,7 +11,7 @@ adu:
   tier: Standard
   bedrooms: 2
   bathrooms: 1
-  stair: ladder
+  stair: ladder-int
   sqft: 653
   cost_tier: medium
   orientation: any

--- a/entries/projects/adu-shed-shade/adu-shed-shade.md
+++ b/entries/projects/adu-shed-shade/adu-shed-shade.md
@@ -15,7 +15,7 @@ adu:
   tier: Standard
   bedrooms: 2
   bathrooms: 1
-  stair: ladder
+  stair: ladder-int
   sqft: 671
   cost_tier: low
   orientation: any

--- a/entries/projects/adu-shell-stair-adaptive/adu-shell-stair-adaptive.md
+++ b/entries/projects/adu-shell-stair-adaptive/adu-shell-stair-adaptive.md
@@ -11,7 +11,7 @@ adu:
   tier: Plus
   bedrooms: 2
   bathrooms: 1
-  stair: straight
+  stair: full-int
   sqft: 621
   cost_tier: high
   orientation: any

--- a/entries/projects/adu-shell-wraparound-porch/adu-shell-wraparound-porch.md
+++ b/entries/projects/adu-shell-wraparound-porch/adu-shell-wraparound-porch.md
@@ -12,7 +12,7 @@ adu:
   bedrooms: 1
   bathrooms: 1
   loft: true
-  stair: ladder
+  stair: ladder-int
   sqft: 581
   cost_tier: medium
   orientation: any


### PR DESCRIPTION
## Summary
- Replace the 5-option STAIR filter on `/adu-library/` with 3 options: Ladder-Int, Full-Int, Full-Ext
- Migrate existing entries: `ladder` → `ladder-int`, `straight` → `full-int`, mishpocha-woods-01 (no stair set) → `full-ext`
- Update `aduStairLabel` filter, admin dropdown, and admin tooltip to match

## Test plan
- [ ] Visit `/adu-library/` — STAIR filter shows 3 checkboxes (LADDER-INT, FULL-INT, FULL-EXT) and each one filters correctly
- [ ] Spec list on each ADU row shows the new label
- [ ] Project detail page Stair row shows the new label
- [ ] Admin entry editor Stair dropdown shows the 3 options and round-trips through save/load