### PR TITLE
Fix premature tier-empty messages on ADU library first load

### DIFF
--- a/adu-library.njk
+++ b/adu-library.njk
@@ -747,6 +747,8 @@ section: adu-library
     document.querySelectorAll('.adu-filters input[type="checkbox"]').forEach(function (cb) { cb.checked = false; });
     rerender();
   });
+
+  rerender();
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- Add a single `rerender()` call at the end of the IIFE in `adu-library.njk` so per-tier empty-state visibility is computed from JS filter state on init, not solely from the server-rendered inline `display:none` fallback.

## Why
Each tier's "No X designs match these filters." placeholder is rendered with inline `style="display:none;"` and was only toggled inside `rerender()`, which previously fired only on `change` / clear-filters `click`. If anything caused the inline style to drift out of sync (bfcache restore, browser autofill, etc.), the messages could leak through on first paint. Running `rerender()` once at init makes the displayed state always match the JS filter state.

## Test plan
- [ ] Visit `/adu-library/` cold — no "No X designs match these filters." anywhere
- [ ] Toggle STAIR > LADDER-INT — tiers with no ladder-int designs (e.g. Plus) show their message; others don't
- [ ] CLEAR FILTERS clears all messages
- [ ] Browser back/forward navigation does not leave stale messages visible