### PR TITLE
Publish ADU_0303: Monitor + Wraparound Porch

### DIFF
--- a/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
+++ b/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+draft: false
 type: project
 title: 'ADU_0303: Monitor + Wraparound Porch'
 date: 2026-05-13T00:00:00.000Z


### PR DESCRIPTION
## Summary
- Flip `draft: true` → `draft: false` on `entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md` so it appears on `/adu-library/` (the `aduLibrary` collection skips drafts).

## Test plan
- [ ] `/adu-library/` count goes from 8 → 9
- [ ] Entry appears under the Standard tier section
- [ ] `/project/adu-monitor-wraparound-porch/` is reachable