### PR TITLE
Show draft entries in admin panel

### DIFF
--- a/entries/entries.11tydata.js
+++ b/entries/entries.11tydata.js
@@ -42,11 +42,6 @@ export default function() {
         return false;
       },
 
-      eleventyExcludeFromCollections(data) {
-        if (data.draft) return true;
-        return data.eleventyExcludeFromCollections;
-      },
-
       // Auto-discover thumbnail image from entry folder
       thumbnail(data) {
         if (data.thumbnail) return data.thumbnail;


### PR DESCRIPTION
## Summary
- Remove the global `eleventyExcludeFromCollections` directive from `entries/entries.11tydata.js` so drafts appear in `collections.allEntries` (which the admin reads from).
- `permalink: false` already prevents draft pages from being generated, and every public-facing collection (`projects`, `aduLibrary`, `entries`, `entriesByProject`, `allCategories`, sitemap) filters drafts explicitly, so drafts stay hidden from the public.

## Why
The admin page is documented as showing "all entries including drafts" but the global exclusion silently dropped them. This made draft entries impossible to edit in the admin.

## Test plan
- [ ] `/admin/` lists draft entries (e.g. `adu-shell-wraparound-porch`) with the Draft checkbox checked
- [ ] Opening a draft entry in the admin lets you edit all fields and save
- [ ] `/adu-library/` still shows 9 designs (excludes the draft)
- [ ] `/project/adu-shell-wraparound-porch/` 404s
- [ ] `/sitemap.xml` does not contain the draft URL