### PR TITLE
Lead ADU library rows with bed/bath and sqft

### DIFF
--- a/adu-library.njk
+++ b/adu-library.njk
@@ -215,35 +215,39 @@ section: adu-library
     text-transform: uppercase;
     letter-spacing: 0.02em;
   }
+  .adu-row__spec-list--primary {
+    font-weight: bold;
+    color: var(--color-accent-1);
+  }
+  .adu-row__spec-list--secondary {
+    font-size: var(--font-size-small);
+    color: var(--color-accent-2);
+    letter-spacing: 0.05em;
+  }
+  .adu-row__spec-divider {
+    margin: var(--space-1) 0;
+    border-top: var(--grid-line-thickness) var(--grid-line-horizontal-minor-style) var(--grid-line-color);
+  }
   .adu-row__spec-label {
     opacity: 0.6;
     font-weight: normal;
   }
 
   .adu-row__cell--price { text-align: right; }
-  .adu-row__price-range {
-    display: block;
-    font-size: var(--font-size-base);
-    font-weight: bold;
+  .adu-row__cost-pill {
+    display: inline-block;
+    border: var(--grid-line-thickness) solid var(--color-accent-1);
     color: var(--color-accent-1);
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
-  }
-  .adu-row__price-label {
-    display: block;
-    color: var(--color-accent-2);
     font-size: var(--font-size-small);
-    margin-top: var(--space-1);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    padding: var(--space-1) var(--space-2);
+    font-weight: bold;
   }
-  .adu-row__view {
-    display: block;
-    margin-top: var(--space-1);
-    font-size: var(--font-size-small);
+  .adu-row__cost-pill-label {
     color: var(--color-accent-2);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    font-weight: normal;
+    margin-left: var(--space-1);
   }
 
   /* Empty state */
@@ -610,22 +614,23 @@ section: adu-library
 
                   <div class="adu-row__cell">
                     <div class="adu-row__name">{{ project.data.title | upper }}</div>
-                    <span class="adu-row__sub">{{ project.fileSlug }}</span>
+                    <span class="adu-row__sub">{{ adu.tier | upper }}</span>
                   </div>
 
                   <div class="adu-row__cell">
-                    <div class="adu-row__spec-list">
+                    <div class="adu-row__spec-list adu-row__spec-list--primary">
+                      <span>{{ adu.bedrooms }} BR / {{ adu.bathrooms or 1 }} BA{% if adu.loft %} + LOFT{% endif %}</span>
+                      <span>{{ adu.sqft }} SQFT</span>
+                    </div>
+                    <div class="adu-row__spec-divider"></div>
+                    <div class="adu-row__spec-list adu-row__spec-list--secondary">
                       <span><span class="adu-row__spec-label">FOOTPRINT</span> {{ adu.footprint | upper }}</span>
-                      <span><span class="adu-row__spec-label">SQFT</span> {{ adu.sqft }}</span>
-                      <span><span class="adu-row__spec-label">BED/BATH</span> {{ adu.bedrooms }} BR / {{ adu.bathrooms or 1 }} BA{% if adu.loft %} + LOFT{% endif %}</span>
                       <span><span class="adu-row__spec-label">STAIR</span> {{ adu.stair | aduStairLabel | upper }}</span>
                     </div>
                   </div>
 
                   <div class="adu-row__cell adu-row__cell--price">
-                    <span class="adu-row__price-range">{{ adu | aduPriceRange }}</span>
-                    <span class="adu-row__price-label">COST TIER</span>
-                    <span class="adu-row__view arrow--right">VIEW PROJECT</span>
+                    <span class="adu-row__cost-pill">{{ adu | aduPriceRange }} <span class="adu-row__cost-pill-label">COST TIER</span></span>
                     <button class="adu-compare-btn"
                             type="button"
                             data-compare-add="{{ project.fileSlug }}"

--- a/adu-library.njk
+++ b/adu-library.njk
@@ -225,7 +225,7 @@ section: adu-library
     letter-spacing: 0.05em;
   }
   .adu-row__spec-divider {
-    margin: var(--space-1) 0;
+    margin: var(--space-1) calc(var(--space-2) * -1);
     border-top: var(--grid-line-thickness) var(--grid-line-horizontal-minor-style) var(--grid-line-color);
   }
   .adu-row__spec-label {
@@ -233,21 +233,27 @@ section: adu-library
     font-weight: normal;
   }
 
-  .adu-row__cell--price { text-align: right; }
+  .adu-row__cell--price {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
   .adu-row__cost-pill {
     display: inline-block;
-    border: var(--grid-line-thickness) solid var(--color-accent-1);
     color: var(--color-accent-1);
     font-size: var(--font-size-small);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    padding: var(--space-1) var(--space-2);
     font-weight: bold;
   }
   .adu-row__cost-pill-label {
     color: var(--color-accent-2);
     font-weight: normal;
     margin-left: var(--space-1);
+  }
+  .adu-row__cell--price .adu-compare-btn {
+    margin-top: auto;
   }
 
   /* Empty state */


### PR DESCRIPTION
## Summary
- Promote bed/bath config and square footage to headline type in each ADU row's spec column, so homeowner shoppers see the home's shape first.
- Demote footprint and stair to a small secondary line beneath a divider; replace the file slug under each title with the tier name (ESSENTIAL / STANDARD / PLUS).
- Convert the cost-tier display into a single bordered pill that visually separates *value* from *action*, and drop the redundant "VIEW PROJECT" text since the whole row is already a link.

All filter `data-*` attributes, compare-tray metadata, and the 4-column grid skeleton are unchanged — filtering, comparing, and the "Help me choose" quiz continue to work as-is.

## Test plan
- [ ] Load `/adu-library/` — confirm BED/BATH and SQFT read as the largest type in column 3, with FOOTPRINT/STAIR small beneath a divider.
- [ ] Confirm tier name ("ESSENTIAL", "STANDARD", "PLUS") appears under each title instead of the file slug.
- [ ] Confirm column 4 reads as two distinct elements: cost-tier pill on top, COMPARE button below.
- [ ] Hover a row — full-row link still navigates to the project page; COMPARE button still toggles independently.
- [ ] Click COMPARE — compare tray still receives full metadata (bedrooms, sqft, footprint, stair, cost, features).
- [ ] Toggle filters (BEDROOMS, STAIR, COST TIER, FEATURES) — rows show/hide correctly, result count updates.
- [ ] Resize below 840px — single-column stack still reads cleanly.
- [ ] Run "HELP ME CHOOSE" quiz — matched rows render with the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)