### PR TITLE
Add descriptions and bodies for ADU library entries

### DIFF
--- a/entries/projects/adu-gable-shade/adu-gable-shade.md
+++ b/entries/projects/adu-gable-shade/adu-gable-shade.md
@@ -2,7 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0102: Gable + Shade'
-description: Same as the Essential ADU but with a covered porch.
+description: The Gable plan with one roof slope extended into a deep covered porch — same interior, plus a shaded outdoor room running along the length of the house.
 date: 2026-01-02T00:00:00.000Z
 year: '2026'
 location: Open source
@@ -32,12 +32,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
-The Courtyard is a single-story L-plan design with two enclosed bedrooms organized around a small private exterior courtyard. The plan was developed for property owners building an ADU as a long-term rental for older family members or as a multi-generational guest house — every room is on grade, every doorway meets accessible width minimums, and the kitchen and bathrooms are designed to retrofit easily for additional accessibility hardware.
+This home keeps the simple, affordable one-bedroom plan of the basic Gable, but adds a dramatic move on the outside: one side of the roof sweeps all the way down to the ground to form a deep covered porch running the full length of the house. The shade keeps the interior cool in summer and gives you a real outdoor room for a long table, hammocks, or chairs.
 
-## Who it's for
-
-The Courtyard is the most generous single-story design in the library and the most flexible for accessibility. It's the right scale for long-term renters, multi-generational housing, or a property owner who wants the option to age in place in their own ADU later.
-
-## What you can change
-
-The courtyard itself is the design's defining move and isn't structurally optional. But its surface treatment is wide open: gravel, decomposed granite, full hardscape, or a small planted garden are all detailed in the toolkit. The L-plan can be mirrored to suit either left- or right-handed lots without changes to the structural drawings.
+Inside, the layout is the same as the basic Gable — an open great room with a vaulted ceiling, a kitchen along the back wall, a private ground-floor bedroom and bath, and a sleeping loft above. The covered porch costs a little more than a bare gable but pays you back in usable square footage that doesn't count against the conditioned area. It's a strong choice for warm climates, families who like to eat outdoors, or anyone who wants a porch as the front room of the house.

--- a/entries/projects/adu-gable-stair-adaptive/adu-gable-stair-adaptive.md
+++ b/entries/projects/adu-gable-stair-adaptive/adu-gable-stair-adaptive.md
@@ -2,6 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0104: Gable + Stair + Adaptive'
+description: A two-bedroom home with a vaulted great room and a second upstairs room with its own exterior stair — usable as a quiet office, studio, or extra bedroom.
 date: 2026-05-13T00:00:00.000Z
 categories:
   - HOUSING
@@ -27,4 +28,6 @@ adu:
     - stair
     - porch
 ---
+This home is built around a single architectural move: the upstairs room has its own private entrance via an exterior covered stair. Because the upstairs is a single open room without its own bathroom, it isn't a separate apartment — but the private entry lets it serve a lot of different roles. It can be a home office, an art or work studio, a teenager's room, or a quiet guest bedroom. A homeowner could even rent out the downstairs as a one-bedroom unit while keeping the upstairs as their own private workspace.
 
+The ground floor holds a vaulted great room with an open kitchen, a private bedroom, and a full bath. Upstairs is one open bedroom-sized room with its own closet space and a covered landing at the top of the stair. At about 600 square feet of conditioned space, it's a good fit for a household that needs separation between work and home life, a family with a remote worker, or a property owner who wants flexible use of their backyard unit.

--- a/entries/projects/adu-gable/adu-gable.md
+++ b/entries/projects/adu-gable/adu-gable.md
@@ -2,9 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0101: Gable'
-description: >-
-  The most economical in the ADU library. A living room, kitchen, bedroom, and
-  bathroom with a sleeping loft above, accessed by a ladder stair.
+description: A simple one-bedroom home under a steep gable, with an open great room, a ground-floor bedroom and bath, and a sleeping loft above.
 date: 2026-01-01T00:00:00.000Z
 year: '2026'
 location: Open source
@@ -34,12 +32,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
-The Loft Cabin is the most compact design in the LowDO ADU library. A 192-square-foot footprint stretches into 380 square feet of usable space by lifting the sleeping area into a generous loft above the kitchen and bath. Access is by ladder — a deliberate choice that keeps the design small, simple, and inexpensive to build.
+This is the simplest, most affordable home in the collection — a compact one-bedroom plan tucked under a single gable roof. Downstairs is one open great room with a vaulted ceiling and a kitchen along the back wall, plus a private bedroom and full bath behind the stair. A short flight of stairs leads up to a sleeping loft for a guest bed, a workspace, or extra storage.
 
-## Who it's for
-
-This design is intended for property owners who want to add a guest unit, home office, or short-term rental without committing to the cost or complexity of a full second dwelling. It's the cheapest path to a permitted ADU in our library, designed to be buildable by a small contractor or owner-builder team in a season.
-
-## What you can change
-
-The plan is dimensionally tight, but the elevation is flexible. Window placement, exterior cladding, and roof material are all up to you. The included design toolkit shows three exterior variations: cedar siding, board-and-batten, and standing-seam metal.
+The straightforward rectangular shape keeps construction costs low and the build itself short. With a covered entry porch and tall great-room windows, the interior feels generous despite its small size. It works well as a starter home, a quiet retreat for one or two people, or a backyard cottage to rent out or host family in.

--- a/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
+++ b/entries/projects/adu-mishpocha-woods-01/adu-mishpocha-woods-01.md
@@ -2,6 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0501: Mishpocha Woods 01'
+description: A full two-story one-bedroom home with a covered patio downstairs, an upstairs primary suite under cathedral ceilings, and an upper-level covered porch.
 date: 2026-05-13T00:00:00.000Z
 categories:
   - HOUSING
@@ -29,4 +30,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
+This is a true two-story home that feels much larger than its small footprint suggests. The ground floor is a single generous great room with an open kitchen and a powder room — flowing out through a wide opening to a covered patio that doubles the living space when the weather is good. An interior stair leads up to a complete primary suite: a big bedroom under a cathedral ceiling, a full bathroom, a walk-in closet, a tucked-in laundry, and a private upper-level covered porch.
 
+At just under 1,100 square feet, this plan has all the comforts of a regular small house — real rooms with real ceilings, dedicated storage, separate living and sleeping levels, and two distinct outdoor rooms. It's a good fit for a couple, a small family, or someone who wants a complete home rather than a studio, and it works equally well as a primary residence or as a long-term rental on a larger property.

--- a/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
+++ b/entries/projects/adu-mishpocha-woods-02/adu-mishpocha-woods-02.md
@@ -2,6 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0502: Mishpocha Woods 02'
+description: A two-story two-bedroom home with an open kitchen and living room downstairs, a covered porch, and a full primary suite plus a guest bedroom upstairs.
 date: 2026-05-13T00:00:00.000Z
 categories:
   - HOUSING
@@ -29,4 +30,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
+This is the bigger, family-sized version of the Mishpocha Woods plan. Downstairs is one large open kitchen and living room with a generous island, a combined bathroom and utility room with laundry, a coat closet, and a covered porch you can step out onto from the main living space. An interior stair leads to a private upstairs holding the primary bedroom suite — with cathedral ceiling, walk-in closet, and a roomy bathroom — plus a separate guest bedroom and a smaller dedicated bath.
 
+At around 1,260 square feet, this is a complete two-bedroom home that doesn't feel like a starter house. The downstairs is open enough to host friends comfortably; the upstairs gives every member of the household their own space. It works well as a primary residence for a young family, a couple who wants a guest room or home office, or as a long-term rental on a larger property.

--- a/entries/projects/adu-monitor-stair-adaptive/adu-monitor-stair-adaptive.md
+++ b/entries/projects/adu-monitor-stair-adaptive/adu-monitor-stair-adaptive.md
@@ -2,6 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0304: Monitor + Stair + Adaptive'
+description: A two-bedroom home under a monitor roof with clerestory windows above, plus an upstairs room reached by its own exterior stair — ideal as an office or studio.
 date: 2026-05-20T00:00:00.000Z
 categories:
   - HOUSING
@@ -28,4 +29,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
+This home shares the flexibility of the other adaptive plans — the upstairs room has its own exterior stair, so it can be used as a quiet workspace, a home office, a guest bedroom, or a teenager's room without sharing the main entry. The upstairs has no bathroom, so it isn't a standalone studio, but the private entrance still lets a homeowner separate it from the main house entirely — for example, renting out the downstairs while keeping the upstairs as their own office.
 
+What sets this scheme apart is the roof. The distinctive monitor profile — taller on one side, with a band of clerestory windows tucked under the high eave — pulls daylight deep into the great room from above, making the main living space feel bright and lofty without sacrificing privacy. Downstairs holds a vaulted great room with an open kitchen, a private bedroom, and a full bath; upstairs is one open bedroom-sized room with its own closet space and a covered landing. At about 600 conditioned square feet, it's a compact, light-filled home that's flexible enough to grow and change with you.

--- a/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
+++ b/entries/projects/adu-monitor-wraparound-porch/adu-monitor-wraparound-porch.md
@@ -2,6 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0303: Monitor + Wraparound Porch'
+description: A two-bedroom home under a monitor roof with clerestory windows and covered porches on all four sides — maximum natural light and shaded outdoor space.
 date: 2026-05-13T00:00:00.000Z
 categories:
   - HOUSING
@@ -27,4 +28,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
+This home is designed around two ideas: shade and light. Covered porches wrap all four sides of the house, creating a continuous outdoor room that shades the walls and windows from direct sun all day long. The result is a building that stays significantly cooler in summer — a real comfort and energy advantage in hot climates — while also giving you several hundred extra square feet of usable, weather-protected outdoor space.
 
+The monitor roof above the wraparound porch lifts the center of the house higher than the eaves, leaving room for a band of clerestory windows that pull soft, indirect daylight into the great room from above. Inside, the downstairs holds a vaulted great room with an open kitchen, a private bedroom, and a full bath. An interior stair leads up to a second bedroom and a small loft tucked under the roof. At about 630 conditioned square feet, the home itself is compact — but the porches and clerestories make it feel both spacious and bright.

--- a/entries/projects/adu-shed-shade/adu-shed-shade.md
+++ b/entries/projects/adu-shed-shade/adu-shed-shade.md
@@ -2,7 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0202: Shed + Shade'
-description: A shed roof with a fully separated upstairs bedroom.
+description: A two-bedroom home under a single shed roof that extends out to form a deep covered porch — simple to build, with a real second bedroom upstairs.
 date: 2026-01-02T00:00:00.000Z
 year: '2026'
 location: Open source
@@ -31,12 +31,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
-The Switchback is the smallest design in the library to include a true second story. A switchback stair — half a flight, a landing, then a second half flight — makes the journey upstairs feel architectural without consuming the whole footprint. The downstairs is a continuous live/work room with a small deck off the back; the upstairs holds a private bedroom, full bath, and reading loft.
+This home is shaped by one long shed roof that slopes from a high front wall down past the back of the house, creating a deep covered porch on the way. The shape is simple to frame, sheds rain easily, and gives the main living space a tall, light-filled feel with windows up high.
 
-## Who it's for
-
-Property owners who want the spatial generosity of a real two-story ADU but aren't ready to commit to a second bedroom. The Switchback is the right scale for a long-term rental, a creative studio with sleeping space, or a multi-generational guest house.
-
-## What you can change
-
-The deck is dimensionally optional — it can shrink to a small landing or grow to a full outdoor room without affecting the structural design. The stair itself is the main spatial feature and the toolkit includes drawings for both a straight-run and a U-shaped variation.
+Inside, the downstairs holds a vaulted great room with an open kitchen, a small storage room, a private bedroom, and a full bath. An interior stair leads up to a second bedroom — a real enclosed room rather than just a loft — plus a small lofted area and extra storage. At about 657 square feet, this is one of the more affordable two-bedroom plans in the collection. It's a good fit for a couple sharing the home with a child or roommate, or as a long-term rental that can comfortably sleep more than one person.

--- a/entries/projects/adu-shell-stair-adaptive/adu-shell-stair-adaptive.md
+++ b/entries/projects/adu-shell-stair-adaptive/adu-shell-stair-adaptive.md
@@ -2,6 +2,7 @@
 draft: false
 type: project
 title: 'ADU_0404: Shell + Stair + Adaptive'
+description: A two-bedroom home wrapped on all four sides by a sweeping "shell" roof creating continuous shade, with an upstairs room reached by exterior stair — ideal as an office.
 date: 2026-05-13T00:00:00.000Z
 categories:
   - HOUSING
@@ -28,4 +29,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
+This home takes its name from the roof: a single sweeping form that wraps the house on all four sides, extending out and down to create a continuous covered porch around the entire building. The main payoff is solar shading — the deep eaves keep direct sun off every wall and window throughout the day, which significantly reduces cooling load in hot climates — while also adding more than 700 square feet of weather-protected outdoor space.
 
+Like the other adaptive plans, the upstairs room has its own exterior stair. There's no bathroom upstairs, so it isn't a standalone studio, but the private entry lets it serve as a quiet office, a remote-work studio, or a guest bedroom that can be used independently of the main house. Downstairs holds a vaulted great room with an open kitchen, a private bedroom, and a full bath. At about 600 conditioned square feet, the home itself is small — but the shell turns the property into a covered outdoor pavilion that lives much larger than the floor plan.

--- a/entries/projects/adu-shell-wraparound-porch/adu-shell-wraparound-porch.md
+++ b/entries/projects/adu-shell-wraparound-porch/adu-shell-wraparound-porch.md
@@ -2,6 +2,7 @@
 draft: true
 type: project
 title: 'ADU_0403: Shell + Wraparound Porch'
+description: A one-bedroom home wrapped on all four sides by a "shell" roof forming a continuous covered porch — maximum shade and outdoor space, with a sleeping loft above.
 date: 2026-05-13T00:00:00.000Z
 categories:
   - HOUSING
@@ -28,4 +29,6 @@ relatedProjects: []
 relatedEntries: []
 active: true
 ---
+This home uses the same dramatic "shell" roof as its larger sibling: a single sweeping form that wraps around the entire house on all four sides, creating a continuous covered porch all the way around. The main payoff is solar shading — the deep eaves keep direct sun off every wall and window throughout the day, which keeps the interior noticeably cooler in summer — while also adding hundreds of square feet of weather-protected outdoor space that doubles as a porch on any side of the house.
 
+Inside is a simple one-bedroom plan: a great room with an open kitchen, a private ground-floor bedroom, and a full bath. A compact internal stair leads up to a quiet sleeping loft tucked under the high middle of the roof. At about 580 conditioned square feet, this is a small home — but the wraparound shell makes day-to-day living feel much larger and adds a covered outdoor room that's just as usable as any of the indoor ones.


### PR DESCRIPTION
## Summary
- Add a short description blurb (<30 words, for the frontmatter `description` field) and a 2-paragraph body for each of the 10 ADU library entries, framed for a general audience as affordable small homes.
- Replace orphan body text in `adu-gable`, `adu-gable-shade`, and `adu-shed-shade` (which referenced unrelated projects) with copy that matches the actual drawings.
- Bodies are based on a read of each project's plans and sections. Adaptive schemes are framed as flexible office/studio space (not separate rentable units, since the upstairs has no bathroom). Monitor schemes mention clerestory windows. Wraparound porch schemes are described as four-sided for solar shading and outdoor living.

## Test plan
- [ ] Load `/adu-library/` — confirm every row still renders and links into its project page.
- [ ] Spot-check 2–3 project detail pages (`adu-gable`, `adu-shed-shade`, `adu-mishpocha-woods-01`) — confirm description and body copy reads correctly.
- [ ] Confirm no stale references to unrelated projects in the three previously-orphaned entries.
- [ ] Filters, comparison tray, and "Help me choose" quiz on `/adu-library/` still work (this PR is content-only, but a quick sanity pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)