### PR TITLE
Allow any file type for Toolkit uploads

### DIFF
--- a/admin/index.njk
+++ b/admin/index.njk
@@ -314,10 +314,10 @@ eleventyExcludeFromCollections: true
 
               {# Toolkit files #}
               <div class="ep-files-group">
-                <div class="ep-files-group__title"><span data-tooltip="Downloadable files listed in the Toolkit section on the project detail page. Accepts PDF, DWG, DXF, DOC, DOCX, XLS, XLSX.">Toolkit Files</span></div>
+                <div class="ep-files-group__title"><span data-tooltip="Downloadable files listed in the Toolkit section on the project detail page. Accepts any file type.">Toolkit Files</span></div>
                 <div class="ep-files-list" id="ep-files-toolkit-list"></div>
                 <button type="button" class="btn btn--small" id="ep-files-toolkit-add">+ Add File</button>
-                <input type="file" id="ep-files-toolkit-input" accept=".pdf,.dwg,.dxf,.doc,.docx,.xls,.xlsx" hidden>
+                <input type="file" id="ep-files-toolkit-input" hidden>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Lifts the file-type restriction on the **Toolkit Files** uploader in the admin entry editor modal (`/admin/`), so content editors can upload **any file type** as a downloadable Toolkit item.

Previously the Toolkit input only accepted `.pdf, .dwg, .dxf, .doc, .docx, .xls, .xlsx`.

## Change

This is a **client-only** change in `admin/index.njk`:

1. Removed the `accept` attribute from the Toolkit `<input type="file">` so the OS file picker offers every file type.
2. Updated the Toolkit Files tooltip to read "Accepts any file type."

## Why this is all that's needed

Everything downstream of file selection was already file-type-agnostic:

- **Build copy** — `.eleventy.js` copies `entries/**/toolkit-*` with no extension filter.
- **Auto-discovery** — `entries.11tydata.js` matches any `toolkit-*` file and derives the format label from the extension.
- **Rendering** — `project.njk` uses a generic file icon and prints the uppercased extension as the format label.
- **Upload pipeline** — the Netlify function (`update-entries.mjs`) performs no server-side type/size validation; it accepts any base64 blob.

The `accept` attribute was the only thing restricting selection (and it was never a security control).

## Reference: current allowed types per uploader

| Uploader | Allowed types |
|---|---|
| Header Image | Any image (`image/*`) |
| Gallery Images | Any image (`image/*`) |
| Drawings | Any image + PDF, DWG, DXF |
| Toolkit Files | **Any file type** (this PR) — was PDF, DWG, DXF, DOC, DOCX, XLS, XLSX |

## Verification

- Dev server (`npm run serve`) builds cleanly and writes `_site/admin/index.html`.
- In `/admin/`, opening a project entry → **+ Add File** under Toolkit Files now allows selecting any file type; saved files are published as `toolkit-<name>.<ext>` and render in the Design Toolkit section with the correct format label and a working Download link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)