### PR TITLE
Allow multiple files per upload in admin editor

### DIFF
--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -1403,71 +1403,61 @@
     renderFilesHeader(fileOps[activeEditPath]);
   });
 
+  // Read every selected file (async, possibly out of order), then append to the
+  // target list in original selection order and render once. Shared by the
+  // gallery, drawings, and toolkit multi-select inputs.
+  function handleMultiFileSelect(listEl, opsKey) {
+    return function() {
+      var files = this.files;
+      if (!files || !files.length || !activeEditPath) return;
+      var editPath = activeEditPath;                 // capture; may change before reads finish
+      ensureFileOps(editPath);
+      // Capture any in-progress display-name edits ONCE, before mutating the array.
+      syncFileNamesFromRows(listEl, fileOps[editPath][opsKey]);
+
+      var fileArr = Array.prototype.slice.call(files);
+      var results = new Array(fileArr.length);        // index-keyed: preserves order
+      var remaining = fileArr.length;
+
+      fileArr.forEach(function(file, i) {
+        readFileAsBase64(file, function(base64, mimeType) {
+          results[i] = {
+            status: 'upload', base64: base64, mimeType: mimeType,
+            displayName: file.name.replace(/\.[^.]+$/, ''),
+            path: '', origPath: null, _ext: getExtension(file.name)
+          };
+          if (--remaining === 0) finish();
+        });
+      });
+
+      function finish() {
+        // Guard: user may have navigated to a different entry mid-read.
+        if (activeEditPath !== editPath || !fileOps[editPath]) return;
+        results.forEach(function(item) {
+          if (item) fileOps[editPath][opsKey].push(item);
+        });
+        renderFilesList(listEl, fileOps[editPath][opsKey]);
+      }
+    };
+  }
+
   epFilesGalleryAdd.addEventListener('click', function() {
     epFilesGalleryInput.value = '';
     epFilesGalleryInput.click();
   });
-
-  epFilesGalleryInput.addEventListener('change', function() {
-    if (!this.files || !this.files[0] || !activeEditPath) return;
-    var file = this.files[0];
-    readFileAsBase64(file, function(base64, mimeType) {
-      var ext = getExtension(file.name);
-      var defaultName = file.name.replace(/\.[^.]+$/, '');
-      ensureFileOps(activeEditPath);
-      syncFileNamesFromRows(epFilesGalleryList, fileOps[activeEditPath].gallery);
-      fileOps[activeEditPath].gallery.push({
-        status: 'upload', base64: base64, mimeType: mimeType,
-        displayName: defaultName, path: '', origPath: null,
-        _ext: ext
-      });
-      renderFilesList(epFilesGalleryList, fileOps[activeEditPath].gallery);
-    });
-  });
+  epFilesGalleryInput.addEventListener('change', handleMultiFileSelect(epFilesGalleryList, 'gallery'));
 
   epFilesDrawingsAdd.addEventListener('click', function() {
     epFilesDrawingsInput.value = '';
     epFilesDrawingsInput.click();
   });
-
-  epFilesDrawingsInput.addEventListener('change', function() {
-    if (!this.files || !this.files[0] || !activeEditPath) return;
-    var file = this.files[0];
-    readFileAsBase64(file, function(base64, mimeType) {
-      var ext = getExtension(file.name);
-      var defaultName = file.name.replace(/\.[^.]+$/, '');
-      ensureFileOps(activeEditPath);
-      syncFileNamesFromRows(epFilesDrawingsList, fileOps[activeEditPath].drawings);
-      fileOps[activeEditPath].drawings.push({
-        status: 'upload', base64: base64, mimeType: mimeType,
-        displayName: defaultName, path: '', origPath: null,
-        _ext: ext
-      });
-      renderFilesList(epFilesDrawingsList, fileOps[activeEditPath].drawings);
-    });
-  });
+  epFilesDrawingsInput.addEventListener('change', handleMultiFileSelect(epFilesDrawingsList, 'drawings'));
 
   epFilesToolkitAdd.addEventListener('click', function() {
     epFilesToolkitInput.value = '';
     epFilesToolkitInput.click();
   });
-
-  epFilesToolkitInput.addEventListener('change', function() {
-    if (!this.files || !this.files[0] || !activeEditPath) return;
-    var file = this.files[0];
-    readFileAsBase64(file, function(base64, mimeType) {
-      var ext = getExtension(file.name);
-      var defaultName = file.name.replace(/\.[^.]+$/, '');
-      ensureFileOps(activeEditPath);
-      syncFileNamesFromRows(epFilesToolkitList, fileOps[activeEditPath].toolkit);
-      fileOps[activeEditPath].toolkit.push({
-        status: 'upload', base64: base64, mimeType: mimeType,
-        displayName: defaultName, path: '', origPath: null,
-        _ext: ext
-      });
-      renderFilesList(epFilesToolkitList, fileOps[activeEditPath].toolkit);
-    });
-  });
+  epFilesToolkitInput.addEventListener('change', handleMultiFileSelect(epFilesToolkitList, 'toolkit'));
 
   function wireFilesListEvents(listEl, getItems) {
     listEl.addEventListener('click', function(e) {

--- a/admin/index.njk
+++ b/admin/index.njk
@@ -301,7 +301,7 @@ eleventyExcludeFromCollections: true
                 <div class="ep-files-group__title"><span data-tooltip="Appear in the image gallery on the project detail page, below the body text. Accepts JPEG, PNG, WebP, AVIF.">Gallery Images</span></div>
                 <div class="ep-files-list" id="ep-files-gallery-list"></div>
                 <button type="button" class="btn btn--small" id="ep-files-gallery-add">+ Add Image</button>
-                <input type="file" id="ep-files-gallery-input" accept="image/*" hidden>
+                <input type="file" id="ep-files-gallery-input" accept="image/*" multiple hidden>
               </div>
 
               {# Drawings #}
@@ -309,7 +309,7 @@ eleventyExcludeFromCollections: true
                 <div class="ep-files-group__title"><span data-tooltip="Technical drawings displayed in a separate section on the project detail page. Accepts JPEG, PNG, WebP, AVIF, PDF, DWG, DXF.">Drawings</span></div>
                 <div class="ep-files-list" id="ep-files-drawings-list"></div>
                 <button type="button" class="btn btn--small" id="ep-files-drawings-add">+ Add Drawing</button>
-                <input type="file" id="ep-files-drawings-input" accept="image/*,.pdf,.dwg,.dxf" hidden>
+                <input type="file" id="ep-files-drawings-input" accept="image/*,.pdf,.dwg,.dxf" multiple hidden>
               </div>
 
               {# Toolkit files #}
@@ -317,7 +317,7 @@ eleventyExcludeFromCollections: true
                 <div class="ep-files-group__title"><span data-tooltip="Downloadable files listed in the Toolkit section on the project detail page. Accepts any file type.">Toolkit Files</span></div>
                 <div class="ep-files-list" id="ep-files-toolkit-list"></div>
                 <button type="button" class="btn btn--small" id="ep-files-toolkit-add">+ Add File</button>
-                <input type="file" id="ep-files-toolkit-input" hidden>
+                <input type="file" id="ep-files-toolkit-input" multiple hidden>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Lets content editors select **multiple files at once** in the admin entry editor (`/admin/`) instead of one file per click. Applies to the three list uploaders — **Gallery Images**, **Drawings**, and **Toolkit Files**. **Header Image stays single-file** (it is a single replace-one-file slot).

## Changes

**Client-only.** Two files:

### `admin/index.njk`
Added the `multiple` attribute to the gallery, drawings, and toolkit file inputs (header input left single).

### `_includes/assets/js/admin.js`
Replaced the three near-identical single-file `change` handlers with one shared `handleMultiFileSelect(listEl, opsKey)` helper that:
- reads **all** selected files,
- appends them in **selection order** via an index-keyed buffer — so gallery numbering (`01_`, `02_`, …) stays deterministic despite async `FileReader` completion order,
- calls `syncFileNamesFromRows` **once** up front to preserve in-progress display-name edits, and renders **once** per batch,
- captures the active entry path and re-checks it before appending, so a read that finishes after the user navigates to a different entry no longer corrupts the wrong entry's list.

Net result is also less code (the shared helper replaces three duplicated bodies).

## Why no downstream changes

The save → blob-upload → GitHub-commit pipeline already iterates the per-type arrays (`fileOps[...].gallery / drawings / toolkit`) and uploads each item as its own blob, so adding more array items just works.

## Notes / out of scope

- Header Image intentionally unchanged (single slot).
- Pre-existing gap (not addressed): `readFileAsBase64` has no `FileReader` `onerror` handler; a failed read would leave a batch's completion counter stuck. Pre-existing behavior, flagged for a possible future one-line hardening.

## Verification

- Dev server (`npm run serve`) builds cleanly; no errors.
- In `/admin/`, open a **project** entry → "+ Add Image/Drawing/File" now allows multi-select; files appear as rows in selection order, renames are preserved when adding more, and Header still allows only one file.
- On save, all selected files are committed (gallery numbered in selection order; drawings/toolkit prefixed) and render on the project detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)