### PR TITLE
Resize images client-side (fix admin upload timeout)

### DIFF
--- a/_includes/assets/js/admin.js
+++ b/_includes/assets/js/admin.js
@@ -1528,8 +1528,42 @@
     return queue;
   }
 
-  // Upload one pending file directly to R2 (presigned PUT), then attach its record.
-  // Images additionally get their responsive variant ladder generated server-side.
+  // Responsive size ladder + quality for client-side image variants (mirrors the migration output).
+  var R2_WIDTHS = [640, 1080, 1800, 2400];
+  var R2_FORMATS = ['webp', 'jpeg'];
+  var R2_QUALITY = { webp: 0.75, jpeg: 0.8 };
+
+  // Resize a decoded bitmap to a target width via canvas; resolve a Blob in the given format.
+  function resizeToBlob(bitmap, width, fmt) {
+    var scale = Math.min(1, width / bitmap.width);
+    var w = Math.max(1, Math.round(bitmap.width * scale));
+    var h = Math.max(1, Math.round(bitmap.height * scale));
+    var canvas = document.createElement('canvas');
+    canvas.width = w; canvas.height = h;
+    canvas.getContext('2d').drawImage(bitmap, 0, 0, w, h);
+    return new Promise(function(resolve, reject) {
+      canvas.toBlob(function(blob) {
+        blob ? resolve(blob) : reject(new Error('Browser could not encode ' + fmt));
+      }, 'image/' + fmt, R2_QUALITY[fmt]);
+    });
+  }
+
+  // Presign + PUT one blob/file directly to R2 (bytes never pass through the function → any size).
+  function r2Put(key, body, contentType) {
+    return fetch('/.netlify/functions/update-entries', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'presignUpload', token: token, key: key, contentType: contentType })
+    }).then(function(res) {
+      return res.json().then(function(d) { if (!res.ok) throw new Error(d.error || ('presign HTTP ' + res.status)); return d; });
+    }).then(function(d) {
+      return fetch(d.url, { method: 'PUT', headers: { 'Content-Type': contentType }, body: body })
+        .then(function(pr) { if (!pr.ok) throw new Error('R2 upload failed (HTTP ' + pr.status + ')'); });
+    });
+  }
+
+  // Upload one pending file to R2. Images are resized in the BROWSER into the variant ladder
+  // (no server-side processing → no function timeout, handles any size), then the original +
+  // variants are PUT directly to R2.
   function r2UploadOne(q) {
     var item = q.item;
     var ext = item._ext || getExtension(item.file.name);
@@ -1537,37 +1571,38 @@
       ? ('header-' + item._uid)
       : (sanitizeKeyName(item.displayName || item.file.name.replace(/\.[^.]+$/, '')) + '-' + item._uid);
     var key = q.dir + '/' + keyName + '.' + ext;
+    var keyBase = q.dir + '/' + keyName; // variant keys: keyBase-<width>.<fmt>
     var contentType = item.mimeType || item.file.type || 'application/octet-stream';
-    var isImage = isImageExt(ext);
 
-    return fetch('/.netlify/functions/update-entries', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'presignUpload', token: token, key: key, contentType: contentType })
-    }).then(function(res) {
-      return res.json().then(function(d) { if (!res.ok) throw new Error(d.error || ('presign HTTP ' + res.status)); return d; });
-    }).then(function(d) {
-      return fetch(d.url, { method: 'PUT', headers: { 'Content-Type': contentType }, body: item.file })
-        .then(function(pr) { if (!pr.ok) throw new Error('R2 upload failed (HTTP ' + pr.status + ')'); });
-    }).then(function() {
-      if (q.kind === 'toolkit') {
-        item.record = { filename: keyName + '.' + ext, title: item.displayName || keyName, format: ext.toUpperCase(), key: key };
+    // Toolkit / non-image: upload the original as-is (direct PUT, any size).
+    if (q.kind === 'toolkit' || !isImageExt(ext)) {
+      return r2Put(key, item.file, contentType).then(function() {
+        if (q.kind === 'toolkit') {
+          item.record = { filename: keyName + '.' + ext, title: item.displayName || keyName, format: ext.toUpperCase(), key: key };
+        } else {
+          item.record = { src: key, r2: true, widths: [], formats: [] };
+          if (q.kind !== 'header') item.record.caption = item.displayName || keyName;
+        }
         item.status = 'existing';
-        return;
-      }
-      if (!isImage) {
-        // Non-image in an image slot: store as a no-variant record (renders as a plain <img>).
-        item.record = { src: key, r2: true, widths: [], formats: [] };
-        if (q.kind !== 'header') item.record.caption = item.displayName || keyName;
-        item.status = 'existing';
-        return;
-      }
-      return fetch('/.netlify/functions/update-entries', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'processImage', token: token, key: key })
-      }).then(function(res) {
-        return res.json().then(function(d) { if (!res.ok) throw new Error(d.error || ('processImage HTTP ' + res.status)); return d; });
-      }).then(function(meta) {
-        item.record = { src: key, r2: true, width: meta.width, height: meta.height, widths: meta.widths, formats: meta.formats };
+      });
+    }
+
+    // Image: decode once, upload the original, then generate + upload the resized ladder.
+    return createImageBitmap(item.file, { imageOrientation: 'from-image' }).then(function(bitmap) {
+      var srcW = bitmap.width, srcH = bitmap.height;
+      var widths = R2_WIDTHS.filter(function(w) { return w <= srcW; });
+      if (widths.length === 0 && srcW > 0) widths.push(srcW);
+      var jobs = [ r2Put(key, item.file, contentType) ];
+      widths.forEach(function(w) {
+        R2_FORMATS.forEach(function(fmt) {
+          jobs.push(resizeToBlob(bitmap, w, fmt).then(function(blob) {
+            return r2Put(keyBase + '-' + w + '.' + fmt, blob, 'image/' + fmt);
+          }));
+        });
+      });
+      return Promise.all(jobs).then(function() {
+        if (bitmap.close) bitmap.close();
+        item.record = { src: key, r2: true, width: srcW, height: srcH, widths: widths, formats: R2_FORMATS };
         if (q.kind !== 'header') item.record.caption = item.displayName || keyName;
         item.status = 'existing';
       });

--- a/deno.lock
+++ b/deno.lock
@@ -14,6 +14,8 @@
         "npm:@11ty/eleventy-fetch@^5.1.0",
         "npm:@11ty/eleventy-img@^6.0.4",
         "npm:@11ty/eleventy@^3.1.2",
+        "npm:@aws-sdk/client-s3@^3.1064.0",
+        "npm:@aws-sdk/s3-request-presigner@^3.1064.0",
         "npm:@netlify/plugin-lighthouse@^6.0.3",
         "npm:bcryptjs@^3.0.3",
         "npm:clean-css@^5.3.3",

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,10 +10,6 @@
 
 [functions]
   directory = "netlify/functions"
-  node_bundler = "esbuild"
-  # sharp ships native binaries — keep it external so Netlify installs the
-  # linux build instead of esbuild trying to bundle it.
-  external_node_modules = ["sharp"]
 
 [dev]
   command = "npx @11ty/eleventy --serve --port 8080"

--- a/netlify/functions/update-entries.mjs
+++ b/netlify/functions/update-entries.mjs
@@ -1,18 +1,15 @@
 import { verifyToken } from './admin-auth.mjs';
 import matter from 'gray-matter';
-import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import sharp from 'sharp';
 
 const REPO_OWNER = 'lowdo-bay';
 const REPO_NAME = 'lowdo-dot-net';
 const BRANCH = 'main';
 
 // --- Cloudflare R2 (S3 API) -------------------------------------------------
-const R2_WIDTHS = [640, 1080, 1800, 2400];
-const R2_FORMATS = ['webp', 'jpeg'];
-const R2_QUALITY = { webp: 75, jpeg: 80 };
-
+// Image resizing happens in the browser (canvas); the function only mints presigned
+// PUT URLs so the browser can upload originals + variants directly to R2.
 let _r2;
 function r2Client() {
   if (!_r2) {
@@ -28,39 +25,13 @@ function r2Client() {
   return _r2;
 }
 
-// Presigned PUT URL so the browser can upload an original directly to R2.
+// Presigned PUT URL so the browser can upload a file directly to R2.
 async function presignR2Put(key, contentType) {
   const cmd = new PutObjectCommand({
     Bucket: process.env.R2_BUCKET, Key: key, ContentType: contentType || 'application/octet-stream',
     CacheControl: 'public, max-age=31536000, immutable',
   });
   return getSignedUrl(r2Client(), cmd, { expiresIn: 600 });
-}
-
-// Fetch an uploaded original from R2, generate the responsive ladder with sharp,
-// upload the variants back, and return the record fields for the entry frontmatter.
-async function processR2Image(key) {
-  const Bucket = process.env.R2_BUCKET;
-  const obj = await r2Client().send(new GetObjectCommand({ Bucket, Key: key }));
-  const buf = Buffer.from(await obj.Body.transformToByteArray());
-  const meta = await sharp(buf).metadata();
-  const srcW = meta.width || 0, srcH = meta.height || 0;
-  const widths = R2_WIDTHS.filter((w) => w <= srcW);
-  if (widths.length === 0 && srcW > 0) widths.push(srcW);
-
-  const dot = key.lastIndexOf('.');
-  const base = dot >= 0 ? key.slice(0, dot) : key;
-  for (const w of widths) {
-    for (const fmt of R2_FORMATS) {
-      const vbuf = await sharp(buf).resize({ width: w, withoutEnlargement: true })
-        .toFormat(fmt, { quality: R2_QUALITY[fmt] }).toBuffer();
-      await r2Client().send(new PutObjectCommand({
-        Bucket, Key: `${base}-${w}.${fmt}`, Body: vbuf, ContentType: `image/${fmt}`,
-        CacheControl: 'public, max-age=31536000, immutable',
-      }));
-    }
-  }
-  return { width: srcW, height: srcH, widths, formats: R2_FORMATS };
 }
 
 async function githubApi(path, options = {}) {
@@ -305,22 +276,6 @@ export async function handler(event) {
     try {
       const url = await presignR2Put(parsedBody.key, parsedBody.contentType);
       return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url, key: parsedBody.key }) };
-    } catch (err) {
-      return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
-    }
-  }
-
-  // Generate the responsive variant ladder for an already-uploaded R2 original.
-  if (parsedBody.action === 'processImage') {
-    if (!parsedBody.token || !verifyToken(parsedBody.token, secret)) {
-      return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-    }
-    if (!parsedBody.key) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Missing key' }) };
-    }
-    try {
-      const result = await processR2Image(parsedBody.key);
-      return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(result) };
     } catch (err) {
       return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
     }


### PR DESCRIPTION
## Problem
Admin image uploads failed with "Failed to fetch" on large images. Confirmed by timing the production `processImage` function:
- small image (2.3 MB): **12.9 s**
- large image (24 MB): **25.7 s**

Both at Netlify's ~26 s function ceiling — large images tip over → the function is killed → "Failed to fetch."

## Fix
Move image resizing to the **browser**: the admin decodes each image (`createImageBitmap`), generates the WebP+JPEG variant ladder via canvas, and PUTs the original + variants **directly to R2** (presigned). The function now only mints presigned URLs.

- ✅ No function timeout — handles any image size
- ✅ Removes `sharp` from the functions (also drops the bundling config that likely caused the `netlify dev` hang)
- Trade-off: new uploads are WebP+JPEG only (no AVIF); already-migrated images keep their sharp variants. `sharp` stays a dependency for the one-time migration script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)