### PR TITLE
Remove Sample Drawing Set toolkit from alamo-st

### DIFF
--- a/entries/projects/201202_alamo-st/201202_alamo-st.md
+++ b/entries/projects/201202_alamo-st/201202_alamo-st.md
@@ -274,11 +274,6 @@ drawings:
       - 2400
     formats: *ref_0
     caption: drawing Second floor plan and section
-toolkitFiles:
-  - filename: toolkit-Sample Drawing Set.pdf
-    title: Sample Drawing Set
-    format: PDF
-    key: entries/projects/201202_alamo-st/toolkit-Sample Drawing Set.pdf
 ---
 
 **Design Program**


### PR DESCRIPTION
Removes the **Sample Drawing Set** download from the alamo-st project: drops the `toolkitFiles` record from the entry frontmatter (it was the only toolkit file) and deletes the PDF from R2 so nothing is orphaned. Build-verified: 0 toolkit refs on the page; header + drawings still render from R2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)